### PR TITLE
#121 Support driver models with read paths (e.g. Dropbox or Google Drive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ target/
 *.swo
 *.swn
 hub/.nyc_output/
+
+
+#IDEs
+.idea/

--- a/hub/.eslintrc
+++ b/hub/.eslintrc
@@ -4,7 +4,7 @@
   "env": {
     "browser": false,
     "es6": true,
-    "node": true,
+    "node": true
   },
   "rules": {
     "comma-dangle": ["error", "never"],

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1499,12 +1499,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
     "browserify-mime": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
@@ -2053,12 +2047,6 @@
       "requires": {
         "repeating": "2.0.1"
       }
-    },
-    "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -3885,18 +3873,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
-    },
     "gtoken": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
@@ -4000,12 +3976,6 @@
         "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
-    },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4496,12 +4466,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -4638,40 +4602,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -4681,17 +4611,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -4713,33 +4632,10 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -4903,84 +4799,6 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
       }
     },
     "modelo": {

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -20,10 +20,10 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.44",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -69,9 +69,9 @@
       "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -80,7 +80,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -89,9 +89,9 @@
           "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -100,7 +100,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -114,7 +114,7 @@
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.5"
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "babylon": {
@@ -137,10 +137,10 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "debug": "3.1.0",
-        "globals": "11.4.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "babylon": {
@@ -172,9 +172,9 @@
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -190,24 +190,24 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.16.2.tgz",
       "integrity": "sha512-GrkaFoj0/oO36pNs4yLmaYhTujuA3i21FdQik99Fd/APix1uhf01VlpJY4lAteTDFLRNkRx6ydEh7OVvmeUHng==",
       "requires": {
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.5.4",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.9.7",
-        "is": "3.2.1",
+        "array-uniq": "^1.0.3",
+        "arrify": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.1",
+        "google-auto-auth": "^0.9.0",
+        "is": "^3.2.0",
         "log-driver": "1.2.7",
-        "methmeth": "1.1.0",
-        "modelo": "4.2.3",
-        "request": "2.83.0",
-        "retry-request": "3.3.1",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
+        "methmeth": "^1.1.0",
+        "modelo": "^4.2.0",
+        "request": "^2.79.0",
+        "retry-request": "^3.0.0",
+        "split-array-stream": "^1.0.0",
+        "stream-events": "^1.0.1",
+        "string-format-obj": "^1.1.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "extend": {
@@ -222,27 +222,27 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.6.0.tgz",
       "integrity": "sha512-yQ63bJYoiwY220gn/KdTLPoHppAPwFHfG7VFLPwJ+1R5U1eqUN5XV2a7uPj1szGF8/gxlKm2UbE8DgoJJ76DFw==",
       "requires": {
-        "@google-cloud/common": "0.16.2",
-        "arrify": "1.0.1",
-        "async": "2.6.0",
-        "compressible": "2.0.13",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.5.4",
-        "extend": "3.0.1",
-        "gcs-resumable-upload": "0.9.0",
-        "hash-stream-validation": "0.2.1",
-        "is": "3.2.1",
-        "mime": "2.3.1",
-        "mime-types": "2.1.18",
-        "once": "1.4.0",
-        "pumpify": "1.4.0",
-        "request": "2.83.0",
-        "safe-buffer": "5.1.1",
-        "snakeize": "0.1.0",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
+        "@google-cloud/common": "^0.16.1",
+        "arrify": "^1.0.0",
+        "async": "^2.0.1",
+        "compressible": "^2.0.12",
+        "concat-stream": "^1.5.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.0",
+        "gcs-resumable-upload": "^0.9.0",
+        "hash-stream-validation": "^0.2.1",
+        "is": "^3.0.1",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "once": "^1.3.1",
+        "pumpify": "^1.3.3",
+        "request": "^2.83.0",
+        "safe-buffer": "^5.1.1",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "string-format-obj": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "async": {
@@ -250,7 +250,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "^4.14.0"
           }
         },
         "extend": {
@@ -270,7 +270,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -286,7 +286,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -302,10 +302,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -338,8 +338,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "argparse": {
@@ -348,7 +348,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
@@ -366,7 +366,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -387,7 +387,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -422,9 +422,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -487,8 +487,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.4.1",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "azure-storage": {
@@ -496,15 +496,15 @@
       "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.8.1.tgz",
       "integrity": "sha1-7LnQUO8Tleef+7ZSwC/mQ2h77GM=",
       "requires": {
-        "browserify-mime": "1.2.9",
-        "extend": "1.2.1",
+        "browserify-mime": "~1.2.9",
+        "extend": "~1.2.1",
         "json-edm-parser": "0.1.2",
         "md5.js": "1.3.4",
-        "readable-stream": "2.0.6",
-        "request": "2.83.0",
-        "underscore": "1.8.3",
-        "uuid": "3.1.0",
-        "validator": "9.4.1",
+        "readable-stream": "~2.0.0",
+        "request": "~2.83.0",
+        "underscore": "~1.8.3",
+        "uuid": "^3.0.0",
+        "validator": "~9.4.1",
         "xml2js": "0.2.8",
         "xmlbuilder": "0.4.3"
       },
@@ -519,7 +519,7 @@
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
           "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
           "requires": {
-            "sax": "0.5.8"
+            "sax": "0.5.x"
           }
         },
         "xmlbuilder": {
@@ -535,21 +535,21 @@
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.15.1",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
       },
       "dependencies": {
         "glob": {
@@ -558,12 +558,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -572,7 +572,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -583,9 +583,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -600,11 +600,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -613,7 +613,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -624,25 +624,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "minimatch": {
@@ -651,7 +651,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -666,8 +666,8 @@
         "@babel/traverse": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0"
+        "eslint-scope": "~3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
         "babylon": {
@@ -684,14 +684,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -700,9 +700,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -711,10 +711,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -723,10 +723,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -735,9 +735,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -746,11 +746,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -759,8 +759,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -769,8 +769,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -779,8 +779,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -789,9 +789,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -800,11 +800,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -813,12 +813,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -827,8 +827,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -837,7 +837,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -846,7 +846,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -879,9 +879,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -890,7 +890,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -899,7 +899,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -908,11 +908,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -921,15 +921,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -938,8 +938,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -948,7 +948,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -957,8 +957,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -967,7 +967,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -976,9 +976,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -987,7 +987,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -996,9 +996,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1007,10 +1007,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1019,9 +1019,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1030,9 +1030,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1041,8 +1041,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1051,12 +1051,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1065,8 +1065,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1075,7 +1075,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1084,9 +1084,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1095,7 +1095,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1104,7 +1104,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1113,9 +1113,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1124,9 +1124,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1135,8 +1135,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1145,7 +1145,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1154,8 +1154,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -1164,9 +1164,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1183,36 +1183,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.4",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-flow": {
@@ -1221,7 +1221,7 @@
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1230,13 +1230,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1245,8 +1245,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1255,11 +1255,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1268,15 +1268,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1285,10 +1285,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1308,7 +1308,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
       "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "base64-js": {
@@ -1327,7 +1327,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bech32": {
@@ -1352,7 +1352,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bitcoin-ops": {
@@ -1365,21 +1365,21 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
       "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
       "requires": {
-        "bech32": "1.1.3",
-        "bigi": "1.4.2",
-        "bip66": "1.1.5",
-        "bitcoin-ops": "1.4.1",
-        "bs58check": "2.1.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ecurve": "1.0.6",
-        "merkle-lib": "2.0.10",
-        "pushdata-bitcoin": "1.0.1",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1",
-        "typeforce": "1.12.0",
-        "varuint-bitcoin": "1.1.0",
-        "wif": "2.0.6"
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.3.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
       }
     },
     "blockstack": {
@@ -1387,26 +1387,26 @@
       "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-17.2.0.tgz",
       "integrity": "sha512-coEcA4YvU1Z48U49SnqKIE/vbTvLaxPJ/TKO/lVKpX+3asStfAO8L/3LcTq353HqJ32HDpz0rGwXaCJmgSr43g==",
       "requires": {
-        "ajv": "4.11.8",
-        "bigi": "1.4.2",
-        "bitcoinjs-lib": "3.3.2",
-        "cheerio": "0.22.0",
+        "ajv": "^4.11.5",
+        "bigi": "^1.4.2",
+        "bitcoinjs-lib": "^3.3.0",
+        "cheerio": "^0.22.0",
         "custom-protocol-detection-blockstack": "1.1.4",
-        "ecurve": "1.0.6",
-        "elliptic": "6.4.0",
-        "es6-promise": "4.2.4",
-        "isomorphic-fetch": "2.2.1",
-        "jsontokens": "0.7.7",
-        "promise": "7.3.1",
-        "query-string": "4.3.4",
-        "request": "2.83.0",
-        "ripemd160": "2.0.1",
-        "schema-inspector": "1.6.8",
-        "sprintf-js": "1.1.1",
-        "uri-js": "3.0.2",
-        "uuid": "3.2.1",
-        "validator": "7.2.0",
-        "zone-file": "0.2.3"
+        "ecurve": "^1.0.6",
+        "elliptic": "^6.4.0",
+        "es6-promise": "^4.2.4",
+        "isomorphic-fetch": "^2.2.1",
+        "jsontokens": "^0.7.7",
+        "promise": "^7.1.1",
+        "query-string": "^4.3.2",
+        "request": "^2.79.0",
+        "ripemd160": "^2.0.1",
+        "schema-inspector": "^1.6.4",
+        "sprintf-js": "^1.0.3",
+        "uri-js": "^3.0.2",
+        "uuid": "^3.2.1",
+        "validator": "^7.0.0",
+        "zone-file": "^0.2.2"
       },
       "dependencies": {
         "ajv": {
@@ -1414,8 +1414,8 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "uuid": {
@@ -1441,15 +1441,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "iconv-lite": {
@@ -1469,7 +1469,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -1478,7 +1478,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1489,9 +1489,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -1510,8 +1510,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000830",
-        "electron-to-chromium": "1.3.42"
+        "caniuse-lite": "^1.0.30000792",
+        "electron-to-chromium": "^1.3.30"
       }
     },
     "bs58": {
@@ -1519,7 +1519,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.4"
+        "base-x": "^3.0.2"
       }
     },
     "bs58check": {
@@ -1527,8 +1527,8 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
       "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
       "requires": {
-        "bs58": "4.0.1",
-        "create-hash": "1.2.0"
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0"
       }
     },
     "buffer": {
@@ -1536,9 +1536,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-equal": {
@@ -1567,7 +1567,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -1598,12 +1598,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -1611,9 +1611,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
       "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
       "requires": {
-        "ansi-styles": "1.0.0",
-        "has-color": "0.1.7",
-        "strip-ansi": "0.1.1"
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
       }
     },
     "chardet": {
@@ -1633,22 +1633,22 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash.assignin": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.defaults": "4.2.0",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.1",
-        "lodash.pick": "4.4.0",
-        "lodash.reduce": "4.6.0",
-        "lodash.reject": "4.6.0",
-        "lodash.some": "4.6.0"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
       }
     },
     "chokidar": {
@@ -1658,15 +1658,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -1674,8 +1674,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -1690,7 +1690,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -1710,7 +1710,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1729,7 +1729,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1749,7 +1749,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": ">= 1.33.0 < 2"
       }
     },
     "concat-map": {
@@ -1763,10 +1763,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -1779,13 +1779,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1793,7 +1793,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1803,12 +1803,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "content-disposition": {
@@ -1859,8 +1859,8 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
       "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "create-error-class": {
@@ -1868,7 +1868,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -1876,11 +1876,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1888,12 +1888,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -1902,9 +1902,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -1913,8 +1913,8 @@
           "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -1924,7 +1924,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1932,7 +1932,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -1947,10 +1947,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-what": {
@@ -1973,7 +1973,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -1990,7 +1990,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -2005,8 +2005,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -2015,13 +2015,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -2045,7 +2045,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "doctrine": {
@@ -2054,7 +2054,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -2062,8 +2062,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -2083,7 +2083,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -2091,8 +2091,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -2100,7 +2100,27 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
+      }
+    },
+    "dropbox": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/dropbox/-/dropbox-4.0.7.tgz",
+      "integrity": "sha1-aM1wbglrPTB+57iz64r3wCogRBM=",
+      "requires": {
+        "buffer": "^5.0.8",
+        "moment": "^2.19.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "duplexify": {
@@ -2108,10 +2128,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -2120,7 +2140,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -2128,8 +2148,8 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "requires": {
-        "base64url": "2.0.0",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "ecurve": {
@@ -2137,8 +2157,8 @@
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
       "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
       "requires": {
-        "bigi": "1.4.2",
-        "safe-buffer": "5.1.1"
+        "bigi": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -2157,13 +2177,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -2176,7 +2196,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.21"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -2184,7 +2204,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "ent": {
@@ -2203,11 +2223,11 @@
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -2216,9 +2236,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es6-promise": {
@@ -2243,44 +2263,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.0",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.4.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2295,7 +2315,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2304,9 +2324,9 @@
           "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "debug": {
@@ -2324,12 +2344,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -2344,7 +2364,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "strip-ansi": {
@@ -2353,7 +2373,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -2362,7 +2382,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2373,7 +2393,7 @@
       "integrity": "sha512-VpnNeC4E6t2E2NCw8Oveda91p8CPEaujZURC1KhHe4lBRZJla3o0DVvZu1QGXQZO1ZJ4vUmy3TCp95PqGvIZgQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.15.0"
       }
     },
     "eslint-scope": {
@@ -2382,8 +2402,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -2398,8 +2418,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -2414,7 +2434,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2423,7 +2443,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -2455,7 +2475,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2465,7 +2485,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "express": {
@@ -2473,36 +2493,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "statuses": {
@@ -2517,8 +2537,8 @@
       "resolved": "https://registry.npmjs.org/express-winston/-/express-winston-2.5.1.tgz",
       "integrity": "sha512-mDBfUtYNt1hibuvAKK/grxmT+X1DNcAUgKFQaicfv96+A328tK5O+mGCbV8pK5K3UCUW80r1frnNg0PZMkH1yQ==",
       "requires": {
-        "chalk": "0.4.0",
-        "lodash": "4.17.5"
+        "chalk": "~0.4.0",
+        "lodash": "~4.17.5"
       }
     },
     "extend": {
@@ -2532,9 +2552,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2544,7 +2564,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -2579,9 +2599,9 @@
       "integrity": "sha512-KLc3ZhFaLJprO6RhjbJBqGjeVDk1qPQf3P+PE1CK2mjuibSKCbqq3t5eSG1yZPcA4q2VJKk34RxKs3Tuyp9hVg==",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "glob-to-regexp": "0.4.0",
-        "path-to-regexp": "2.2.1"
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1"
       },
       "dependencies": {
         "path-to-regexp": {
@@ -2598,7 +2618,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2607,8 +2627,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -2624,8 +2644,8 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
       }
     },
     "fill-range": {
@@ -2635,11 +2655,11 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -2648,12 +2668,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -2669,10 +2689,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flow-bin": {
@@ -2686,7 +2706,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
       "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -2705,7 +2725,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "for-in": {
@@ -2722,7 +2742,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2741,9 +2761,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -2781,8 +2801,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -2797,8 +2817,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -2818,8 +2838,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -2863,7 +2883,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -2871,7 +2891,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -2879,7 +2899,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -2887,7 +2907,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -2918,7 +2938,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -2941,7 +2961,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -2950,7 +2970,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2999,7 +3019,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -3025,9 +3045,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -3040,10 +3060,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -3052,9 +3072,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -3063,14 +3083,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -3079,7 +3099,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -3095,12 +3115,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -3120,8 +3140,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -3135,10 +3155,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -3152,9 +3172,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -3162,8 +3182,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3182,7 +3202,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -3208,7 +3228,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -3229,7 +3249,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -3274,7 +3294,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -3282,7 +3302,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -3310,17 +3330,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -3329,8 +3349,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -3339,10 +3359,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -3367,7 +3387,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -3388,8 +3408,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -3426,10 +3446,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3445,13 +3465,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -3460,28 +3480,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -3489,7 +3509,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -3520,7 +3540,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -3529,15 +3549,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -3553,9 +3573,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -3563,7 +3583,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -3577,7 +3597,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3591,9 +3611,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -3602,14 +3622,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -3618,7 +3638,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -3627,7 +3647,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -3668,7 +3688,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3695,8 +3715,8 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
       "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
-        "axios": "0.18.0",
-        "extend": "3.0.1",
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
         "retry-axios": "0.3.2"
       },
       "dependencies": {
@@ -3712,13 +3732,13 @@
       "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.9.0.tgz",
       "integrity": "sha512-+Zrmr0JKO2y/2mg953TW6JLu+NAMHqQsKzqCm7CIT24gMQakolPJCMzDleVpVjXAqB7ZCD276tcUq2ebOfqTug==",
       "requires": {
-        "buffer-equal": "1.0.0",
-        "configstore": "3.1.2",
-        "google-auto-auth": "0.9.7",
-        "pumpify": "1.4.0",
-        "request": "2.83.0",
-        "stream-events": "1.0.4",
-        "through2": "2.0.3"
+        "buffer-equal": "^1.0.0",
+        "configstore": "^3.0.0",
+        "google-auto-auth": "^0.9.0",
+        "pumpify": "^1.3.3",
+        "request": "^2.81.0",
+        "stream-events": "^1.0.1",
+        "through2": "^2.0.0"
       }
     },
     "get-func-name": {
@@ -3732,7 +3752,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3742,8 +3762,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3752,7 +3772,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glob-to-regexp": {
@@ -3773,12 +3793,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3787,12 +3807,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -3801,7 +3821,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -3811,13 +3831,13 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
       "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
       "requires": {
-        "axios": "0.18.0",
-        "gcp-metadata": "0.6.3",
-        "gtoken": "2.3.0",
-        "jws": "3.1.4",
-        "lodash.isstring": "4.0.1",
-        "lru-cache": "4.1.2",
-        "retry-axios": "0.3.2"
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.6.2",
+        "gtoken": "^2.2.0",
+        "jws": "^3.1.4",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.2",
+        "retry-axios": "^0.3.2"
       },
       "dependencies": {
         "lru-cache": {
@@ -3825,8 +3845,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
           "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -3836,10 +3856,10 @@
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.7.tgz",
       "integrity": "sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==",
       "requires": {
-        "async": "2.6.0",
-        "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.4.0",
-        "request": "2.83.0"
+        "async": "^2.3.0",
+        "gcp-metadata": "^0.6.1",
+        "google-auth-library": "^1.3.1",
+        "request": "^2.79.0"
       },
       "dependencies": {
         "async": {
@@ -3847,7 +3867,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -3857,8 +3877,8 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.5",
-        "pify": "3.0.0"
+        "node-forge": "^0.7.4",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3878,11 +3898,11 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
-        "axios": "0.18.0",
-        "google-p12-pem": "1.0.2",
-        "jws": "3.1.4",
-        "mime": "2.3.1",
-        "pify": "3.0.0"
+        "axios": "^0.18.0",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.4",
+        "mime": "^2.2.0",
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "mime": {
@@ -3907,8 +3927,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -3917,7 +3937,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -3926,7 +3946,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -3945,8 +3965,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash-stream-validation": {
@@ -3954,7 +3974,7 @@
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "hash.js": {
@@ -3962,8 +3982,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -3971,10 +3991,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hmac-drbg": {
@@ -3982,9 +4002,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -3998,8 +4018,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "htmlparser2": {
@@ -4007,12 +4027,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.0.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-errors": {
@@ -4020,10 +4040,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -4031,9 +4051,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -4041,7 +4061,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
       "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "^2.1.0"
       }
     },
     "ieee754": {
@@ -4066,8 +4086,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4081,20 +4101,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4109,7 +4129,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4118,9 +4138,9 @@
           "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "strip-ansi": {
@@ -4129,7 +4149,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -4138,7 +4158,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4149,7 +4169,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -4169,7 +4189,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -4203,7 +4223,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4225,7 +4245,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4246,7 +4266,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-number": {
@@ -4256,7 +4276,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -4282,7 +4302,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -4291,7 +4311,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -4320,7 +4340,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -4376,8 +4396,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       },
       "dependencies": {
         "node-fetch": {
@@ -4385,8 +4405,8 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
           "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
           }
         }
       }
@@ -4413,8 +4433,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4434,7 +4454,7 @@
       "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
       "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
       "requires": {
-        "jsonparse": "1.2.0"
+        "jsonparse": "~1.2.0"
       }
     },
     "json-schema": {
@@ -4452,7 +4472,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -4487,11 +4507,11 @@
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.7.tgz",
       "integrity": "sha512-IuW4Q7gj9Hm/ZSjT7U5PEI1ZS8sfPj2ZOV9+5kEo4iVYVSjfs25wPvNUpq/Mkmdmz3VIe1KWIBwIBv2M+ML1Fw==",
       "requires": {
-        "asn1.js": "4.10.1",
-        "base64url": "2.0.0",
-        "elliptic": "6.4.0",
-        "key-encoder": "1.1.6",
-        "validator": "7.2.0"
+        "asn1.js": "^4.9.1",
+        "base64url": "^2.0.0",
+        "elliptic": "^6.3.2",
+        "key-encoder": "^1.1.6",
+        "validator": "^7.0.0"
       },
       "dependencies": {
         "validator": {
@@ -4520,7 +4540,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -4528,9 +4548,9 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
       "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "jwa": "^1.1.4",
+        "safe-buffer": "^5.0.1"
       }
     },
     "key-encoder": {
@@ -4538,9 +4558,9 @@
       "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-1.1.6.tgz",
       "integrity": "sha1-ATVYLNPQp+t5LZTso4e2gejloq0=",
       "requires": {
-        "asn1.js": "2.2.1",
-        "bn.js": "3.3.0",
-        "elliptic": "5.2.1"
+        "asn1.js": "^2.2.0",
+        "bn.js": "^3.1.2",
+        "elliptic": "^5.1.0"
       },
       "dependencies": {
         "asn1.js": {
@@ -4548,9 +4568,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
           "integrity": "sha1-yLpN1o6EQxKIEmIwyyBFvfqfv+E=",
           "requires": {
-            "bn.js": "2.2.0",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "bn.js": "^2.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           },
           "dependencies": {
             "bn.js": {
@@ -4570,10 +4590,10 @@
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
           "integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
           "requires": {
-            "bn.js": "3.3.0",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "inherits": "2.0.3"
+            "bn.js": "^3.1.1",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         }
       }
@@ -4584,7 +4604,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "levn": {
@@ -4593,8 +4613,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -4678,7 +4698,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "make-dir": {
@@ -4686,7 +4706,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -4701,8 +4721,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "media-typer": {
@@ -4737,19 +4757,19 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
@@ -4767,7 +4787,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -4812,6 +4832,11 @@
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4847,15 +4872,15 @@
       "integrity": "sha512-ciCpyEq72Ws6/yhdayDfd0mAb3eQ7/533xKmFlBQZ5CDwrL0/bddtSicfL7R07oyvPAuegQrR+9ctrlPEp0EjQ==",
       "dev": true,
       "requires": {
-        "chai": "4.1.2",
-        "debug": "3.1.0",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "propagate": "1.0.0",
-        "qs": "6.5.1",
-        "semver": "5.5.0"
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "debug": {
@@ -4891,7 +4916,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm": {
@@ -4899,123 +4924,123 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz",
       "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
       "requires": {
-        "JSONStream": "1.3.2",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.0",
-        "bluebird": "3.5.1",
-        "cacache": "10.0.4",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.6.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "1.0.0",
-        "json-parse-better-errors": "1.0.1",
-        "lazy-property": "1.0.0",
-        "libcipm": "1.6.0",
-        "libnpx": "10.0.1",
-        "lockfile": "1.0.3",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
-        "npm-package-arg": "6.0.0",
-        "npm-packlist": "1.1.10",
-        "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.1",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.5",
-        "pacote": "7.6.1",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.11.0",
-        "query-string": "5.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.5",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "5.2.4",
-        "strip-ansi": "4.0.0",
-        "tar": "4.4.0",
-        "text-table": "0.2.0",
+        "JSONStream": "^1.3.2",
+        "abbrev": "~1.1.1",
+        "ansi-regex": "~3.0.0",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.0",
+        "bluebird": "~3.5.1",
+        "cacache": "^10.0.4",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "cli-table2": "~0.2.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.6.0",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "~1.0.0",
+        "json-parse-better-errors": "^1.0.1",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^1.6.0",
+        "libnpx": "^10.0.1",
+        "lockfile": "~1.0.3",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "~4.1.1",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.0.1",
+        "npm-package-arg": "~6.0.0",
+        "npm-packlist": "~1.1.10",
+        "npm-profile": "^3.0.1",
+        "npm-registry-client": "^8.5.1",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "~1.4.3",
+        "osenv": "^0.1.5",
+        "pacote": "^7.6.1",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "~0.11.0",
+        "query-string": "^5.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "~5.1.6",
+        "readable-stream": "^2.3.5",
+        "readdir-scoped-modules": "*",
+        "request": "~2.83.0",
+        "retry": "~0.10.1",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "~5.1.1",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^5.2.4",
+        "strip-ansi": "~4.0.0",
+        "tar": "^4.4.0",
+        "text-table": "~0.2.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.3.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.5.4",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "~2.3.0",
+        "uuid": "^3.2.1",
+        "validate-npm-package-license": "*",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "~1.3.0",
+        "worker-farm": "^1.5.4",
+        "wrappy": "~1.0.2",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           },
           "dependencies": {
             "jsonparse": {
@@ -5056,12 +5081,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "fs-write-stream-atomic": "1.0.10",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "fs-write-stream-atomic": "^1.0.10",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "slide": "^1.1.6"
           }
         },
         "bluebird": {
@@ -5072,44 +5097,44 @@
           "version": "10.0.4",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
-            "mississippi": "2.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "5.2.4",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.1",
+            "mississippi": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^5.2.4",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "mississippi": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "1.6.1",
-                "duplexify": "3.5.4",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.5",
-                    "typedarray": "0.0.6"
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.2.2",
+                    "typedarray": "^0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -5122,10 +5147,10 @@
                   "version": "3.5.4",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.5",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.0.0",
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -5138,32 +5163,32 @@
                   "version": "1.4.1",
                   "bundled": true,
                   "requires": {
-                    "once": "1.4.0"
+                    "once": "^1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.5"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.4"
                   }
                 },
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.5"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0"
                   }
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.5"
+                    "cyclist": "~0.2.2",
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.1.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -5176,25 +5201,25 @@
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 },
                 "pumpify": {
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
-                    "duplexify": "3.5.4",
-                    "inherits": "2.0.3",
-                    "pump": "2.0.1"
+                    "duplexify": "^3.5.3",
+                    "inherits": "^2.0.3",
+                    "pump": "^2.0.0"
                   }
                 },
                 "stream-each": {
                   "version": "1.2.2",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.1.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -5207,8 +5232,8 @@
                   "version": "2.0.3",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "2.3.5",
-                    "xtend": "4.0.1"
+                    "readable-stream": "^2.1.5",
+                    "xtend": "~4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -5237,9 +5262,9 @@
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
+            "colors": "^1.1.2",
+            "lodash": "^3.10.1",
+            "string-width": "^1.0.1"
           },
           "dependencies": {
             "colors": {
@@ -5255,9 +5280,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
@@ -5268,7 +5293,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -5281,7 +5306,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -5298,23 +5323,23 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -5327,14 +5352,14 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -5351,8 +5376,8 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -5377,8 +5402,8 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -5399,45 +5424,45 @@
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.5"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "fs.realpath": {
@@ -5448,14 +5473,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -5501,8 +5526,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5517,21 +5542,21 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.0.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -5561,37 +5586,37 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "bin-links": "1.1.0",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.0",
-            "npm-lifecycle": "2.0.1",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.0.0",
-            "pacote": "7.6.1",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.5.4"
+            "bin-links": "^1.1.0",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.0",
+            "npm-lifecycle": "^2.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.0.0",
+            "pacote": "^7.5.1",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.12",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.5.4"
           },
           "dependencies": {
             "lock-verify": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.5.0"
+                "npm-package-arg": "^5.1.2",
+                "semver": "^5.4.1"
               },
               "dependencies": {
                 "npm-package-arg": {
                   "version": "5.1.2",
                   "bundled": true,
                   "requires": {
-                    "hosted-git-info": "2.6.0",
-                    "osenv": "0.1.5",
-                    "semver": "5.5.0",
-                    "validate-npm-package-name": "3.0.0"
+                    "hosted-git-info": "^2.4.2",
+                    "osenv": "^0.1.4",
+                    "semver": "^5.1.0",
+                    "validate-npm-package-name": "^3.0.0"
                   }
                 }
               }
@@ -5604,7 +5629,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -5617,15 +5642,15 @@
               "version": "1.5.4",
               "bundled": true,
               "requires": {
-                "errno": "0.1.7",
-                "xtend": "4.0.1"
+                "errno": "~0.1.7",
+                "xtend": "~4.0.1"
               },
               "dependencies": {
                 "errno": {
                   "version": "0.1.7",
                   "bundled": true,
                   "requires": {
-                    "prr": "1.0.1"
+                    "prr": "~1.0.1"
                   },
                   "dependencies": {
                     "prr": {
@@ -5646,14 +5671,14 @@
           "version": "10.0.1",
           "bundled": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.3.0",
-            "which": "1.3.0",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -5668,44 +5693,44 @@
               "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.0.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
               },
               "dependencies": {
                 "cliui": {
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1",
-                    "strip-ansi": "4.0.0",
-                    "wrap-ansi": "2.1.0"
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -5716,7 +5741,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -5731,7 +5756,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "2.1.1"
+                            "ansi-regex": "^2.0.0"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -5752,29 +5777,29 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-limit": "1.2.0"
+                            "p-limit": "^1.1.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "p-try": "1.0.0"
+                                "p-try": "^1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -5801,38 +5826,38 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
+                    "execa": "^0.7.0",
+                    "lcid": "^1.0.0",
+                    "mem": "^1.1.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -5855,7 +5880,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -5882,7 +5907,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -5895,7 +5920,7 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -5922,8 +5947,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -5944,7 +5969,7 @@
                   "version": "9.0.2",
                   "bundled": true,
                   "requires": {
-                    "camelcase": "4.1.0"
+                    "camelcase": "^4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -5969,8 +5994,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           },
           "dependencies": {
             "lodash._createset": {
@@ -5995,7 +6020,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -6026,8 +6051,8 @@
           "version": "4.1.1",
           "bundled": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -6048,25 +6073,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "duplexify": "3.5.4",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.4.0",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -6079,10 +6104,10 @@
               "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -6095,32 +6120,32 @@
               "version": "1.4.1",
               "bundled": true,
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
               }
             },
             "from2": {
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
               }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -6133,25 +6158,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
               },
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 }
               }
@@ -6160,8 +6185,8 @@
               "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -6174,8 +6199,8 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -6203,31 +6228,31 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
               }
             },
             "run-queue": {
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
               }
             }
           }
@@ -6236,25 +6261,25 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -6273,21 +6298,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.6.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
+            "umask": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -6298,43 +6323,43 @@
               "version": "3.6.2",
               "bundled": true,
               "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.5",
-                "request": "2.83.0",
-                "rimraf": "2.6.2",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.3.0"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
               },
               "dependencies": {
                 "fstream": {
                   "version": "1.0.11",
                   "bundled": true,
                   "requires": {
-                    "graceful-fs": "4.1.11",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.2"
+                    "graceful-fs": "^4.1.2",
+                    "inherits": "~2.0.0",
+                    "mkdirp": ">=0.5 0",
+                    "rimraf": "2"
                   }
                 },
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.11"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.11",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -6354,7 +6379,7 @@
                   "version": "3.0.6",
                   "bundled": true,
                   "requires": {
-                    "abbrev": "1.1.1"
+                    "abbrev": "1"
                   }
                 },
                 "semver": {
@@ -6365,16 +6390,16 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "block-stream": "0.0.9",
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3"
+                    "block-stream": "*",
+                    "fstream": "^1.0.2",
+                    "inherits": "2"
                   },
                   "dependencies": {
                     "block-stream": {
                       "version": "0.0.9",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                       }
                     }
                   }
@@ -6391,39 +6416,39 @@
           "version": "6.0.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.5.0",
+            "osenv": "^0.1.4",
+            "semver": "^5.4.1",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -6451,39 +6476,39 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
+            "aproba": "^1.1.2",
+            "make-fetch-happen": "^2.5.0"
           },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.2.4"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -6502,22 +6527,22 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "agent-base": "4",
+                    "debug": "2"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6547,22 +6572,22 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6592,25 +6617,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -6623,10 +6648,10 @@
                       "version": "3.5.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -6639,32 +6664,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -6677,25 +6702,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -6704,8 +6729,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -6718,8 +6743,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.5",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -6734,16 +6759,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -6762,8 +6787,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -6776,22 +6801,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6806,8 +6831,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -6830,27 +6855,27 @@
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.0.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.83.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.1",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.2.4"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -6869,18 +6894,18 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.5"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               },
               "dependencies": {
                 "delegates": {
@@ -6897,14 +6922,14 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -6919,9 +6944,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -6932,7 +6957,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -6947,7 +6972,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -6960,7 +6985,7 @@
                   "version": "1.1.2",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
+                    "string-width": "^1.0.2"
                   }
                 }
               }
@@ -6975,7 +7000,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -6986,8 +7011,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -7004,30 +7029,30 @@
           "version": "7.6.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "10.0.4",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.6.0",
-            "minimatch": "3.0.4",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.0.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "semver": "5.5.0",
-            "ssri": "5.2.4",
-            "tar": "4.4.0",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
+            "bluebird": "^3.5.1",
+            "cacache": "^10.0.4",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.1",
+            "make-fetch-happen": "^2.6.0",
+            "minimatch": "^3.0.4",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.0.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.1",
+            "semver": "^5.5.0",
+            "ssri": "^5.2.4",
+            "tar": "^4.4.0",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -7038,31 +7063,31 @@
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.0",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.2.4"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -7081,7 +7106,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -7089,14 +7114,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7126,22 +7151,22 @@
                   "version": "2.2.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7171,25 +7196,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.1",
-                    "duplexify": "3.5.4",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.1",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -7202,10 +7227,10 @@
                       "version": "3.5.4",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -7218,32 +7243,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.5"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -7256,25 +7281,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.4",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -7283,8 +7308,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -7297,8 +7322,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.5",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -7313,16 +7338,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -7341,22 +7366,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7371,8 +7396,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -7393,14 +7418,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -7420,16 +7445,16 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "6.0.0",
-                "semver": "5.5.0"
+                "npm-package-arg": "^6.0.0",
+                "semver": "^5.4.1"
               }
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
               },
               "dependencies": {
                 "err-code": {
@@ -7442,7 +7467,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -7469,9 +7494,9 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -7496,7 +7521,7 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -7509,20 +7534,20 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -7535,11 +7560,11 @@
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -7556,24 +7581,24 @@
           "version": "5.1.6",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -7592,7 +7617,7 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
               }
             },
             "util-deprecate": {
@@ -7605,38 +7630,38 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "request": {
           "version": "2.83.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -7655,7 +7680,7 @@
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -7676,9 +7701,9 @@
               "version": "2.3.1",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -7691,18 +7716,18 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "5.2.3",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               },
               "dependencies": {
                 "ajv": {
                   "version": "5.2.3",
                   "bundled": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.0.0",
-                    "json-schema-traverse": "0.3.1",
-                    "json-stable-stringify": "1.0.1"
+                    "co": "^4.6.0",
+                    "fast-deep-equal": "^1.0.0",
+                    "json-schema-traverse": "^0.3.0",
+                    "json-stable-stringify": "^1.0.1"
                   },
                   "dependencies": {
                     "co": {
@@ -7721,7 +7746,7 @@
                       "version": "1.0.1",
                       "bundled": true,
                       "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
@@ -7742,31 +7767,31 @@
               "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.0.2"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.0"
+                    "hoek": "4.x.x"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.2.0"
+                    "boom": "5.x.x"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                       }
                     }
                   }
@@ -7779,7 +7804,7 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.0"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -7788,9 +7813,9 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -7819,9 +7844,9 @@
                       "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -7836,14 +7861,14 @@
                   "version": "1.13.1",
                   "bundled": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -7855,14 +7880,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                       }
                     },
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -7870,14 +7895,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "jsbn": {
@@ -7910,7 +7935,7 @@
               "version": "2.1.17",
               "bundled": true,
               "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -7939,7 +7964,7 @@
               "version": "2.3.3",
               "bundled": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -7952,7 +7977,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
               }
             }
           }
@@ -7965,7 +7990,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -7980,8 +8005,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.5"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -7996,26 +8021,26 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -8038,8 +8063,8 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "readable-stream": "^2.1.5",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -8054,14 +8079,14 @@
           "version": "5.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.1.1"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8074,33 +8099,33 @@
           "version": "4.4.0",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.1",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.3",
+            "minipass": "^2.2.1",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.1"
+                "minipass": "^2.2.1"
               }
             },
             "minipass": {
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "yallist": "3.0.2"
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.1"
+                "minipass": "^2.2.1"
               }
             },
             "yallist": {
@@ -8125,14 +8150,14 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -8145,35 +8170,35 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.2.1",
-            "chalk": "2.1.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           },
           "dependencies": {
             "boxen": {
               "version": "1.2.1",
               "bundled": true,
               "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.1.0",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "1.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^1.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.0.0"
                   }
                 },
                 "camelcase": {
@@ -8188,8 +8213,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -8202,36 +8227,36 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0"
+                    "execa": "^0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -8254,7 +8279,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -8283,16 +8308,16 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
+                    "string-width": "^1.0.1"
                   },
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -8303,7 +8328,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "number-is-nan": "1.0.1"
+                            "number-is-nan": "^1.0.0"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -8316,7 +8341,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "2.1.1"
+                            "ansi-regex": "^2.0.0"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -8335,23 +8360,23 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "1.9.0"
+                    "color-convert": "^1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.0",
                       "bundled": true,
                       "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                       },
                       "dependencies": {
                         "color-name": {
@@ -8370,7 +8395,7 @@
                   "version": "4.4.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "2.0.0"
+                    "has-flag": "^2.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -8385,19 +8410,19 @@
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
                   "requires": {
-                    "is-obj": "1.0.1"
+                    "is-obj": "^1.0.0"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -8410,7 +8435,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "2.3.0"
+                    "pify": "^2.3.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -8423,7 +8448,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "crypto-random-string": "1.0.0"
+                    "crypto-random-string": "^1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -8442,22 +8467,22 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "global-dirs": "0.1.0",
-                "is-path-inside": "1.0.0"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.0",
                   "bundled": true,
                   "requires": {
-                    "ini": "1.3.5"
+                    "ini": "^1.3.4"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "path-is-inside": "1.0.2"
+                    "path-is-inside": "^1.0.1"
                   }
                 }
               }
@@ -8470,41 +8495,41 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
+                    "got": "^6.7.1",
+                    "registry-auth-token": "^3.0.1",
+                    "registry-url": "^3.0.3",
+                    "semver": "^5.1.0"
                   },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
                       "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
                           "requires": {
-                            "capture-stack-trace": "1.0.0"
+                            "capture-stack-trace": "^1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -8549,7 +8574,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "prepend-http": "1.0.4"
+                            "prepend-http": "^1.0.1"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -8564,18 +8589,18 @@
                       "version": "3.3.1",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "~0.4.0",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -8598,17 +8623,17 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.1"
+                        "rc": "^1.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "~0.4.0",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -8635,7 +8660,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
               }
             },
             "xdg-basedir": {
@@ -8652,15 +8677,15 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           },
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "^1.0.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -8679,7 +8704,7 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -8692,7 +8717,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -8705,15 +8730,15 @@
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7",
-            "xtend": "4.0.1"
+            "errno": "~0.1.7",
+            "xtend": "~4.0.1"
           },
           "dependencies": {
             "errno": {
               "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -8736,9 +8761,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -8754,7 +8779,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "number-is-nan": {
@@ -8769,33 +8794,33 @@
       "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.3",
-        "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.3.0",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.1.0",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.2.1",
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.2",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.10.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.3",
+        "istanbul-reports": "^1.1.4",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
         "yargs": "11.1.0",
-        "yargs-parser": "8.1.0"
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -8803,9 +8828,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -8828,7 +8853,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -8841,7 +8866,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -8884,9 +8909,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -8894,14 +8919,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.5",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -8909,7 +8934,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -8917,8 +8942,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -8926,11 +8951,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.5"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -8938,15 +8963,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.3",
-            "lodash": "4.17.5"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -8954,10 +8979,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.5",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -8975,13 +9000,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -8989,7 +9014,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "isobject": {
@@ -9004,7 +9029,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9013,9 +9038,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -9028,15 +9053,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9051,9 +9076,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -9068,8 +9093,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -9077,11 +9102,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "class-utils": {
@@ -9089,10 +9114,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -9100,7 +9125,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9108,7 +9133,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9116,7 +9141,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9126,7 +9151,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9134,7 +9159,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9144,9 +9169,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "isobject": {
@@ -9167,8 +9192,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -9190,8 +9215,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "commondir": {
@@ -9229,8 +9254,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -9261,7 +9286,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "define-property": {
@@ -9269,8 +9294,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -9285,7 +9310,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -9293,7 +9318,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -9311,13 +9336,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -9325,9 +9350,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             }
           }
@@ -9337,7 +9362,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -9345,7 +9370,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extend-shallow": {
@@ -9353,8 +9378,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -9362,7 +9387,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -9372,7 +9397,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -9385,11 +9410,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-cache-dir": {
@@ -9397,9 +9422,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -9407,7 +9432,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -9420,7 +9445,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "foreground-child": {
@@ -9428,8 +9453,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fragment-cache": {
@@ -9437,7 +9462,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "fs.realpath": {
@@ -9465,12 +9490,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -9478,8 +9503,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -9487,7 +9512,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -9505,10 +9530,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -9516,7 +9541,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -9526,7 +9551,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -9539,9 +9564,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9556,8 +9581,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -9565,7 +9590,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9573,7 +9598,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9583,7 +9608,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9603,8 +9628,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9617,7 +9642,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -9630,7 +9655,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -9655,7 +9680,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-data-descriptor": {
@@ -9663,7 +9688,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -9678,9 +9703,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9700,7 +9725,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -9718,7 +9743,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -9731,7 +9756,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -9739,7 +9764,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-odd": {
@@ -9747,7 +9772,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "4.0.0"
+            "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -9762,7 +9787,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -9825,7 +9850,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -9833,13 +9858,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.1",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "semver": "5.5.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -9847,10 +9872,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -9858,7 +9883,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -9868,11 +9893,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -9890,7 +9915,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.11"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -9908,7 +9933,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -9922,7 +9947,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -9930,11 +9955,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -9942,8 +9967,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -9968,7 +9993,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -9976,8 +10001,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "map-cache": {
@@ -9990,7 +10015,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "md5-hex": {
@@ -9998,7 +10023,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -10011,7 +10036,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -10019,7 +10044,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -10034,19 +10059,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mimic-fn": {
@@ -10059,7 +10084,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -10072,8 +10097,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -10081,7 +10106,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -10104,18 +10129,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -10140,10 +10165,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -10151,7 +10176,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "npm-run-path": {
@@ -10159,7 +10184,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -10177,9 +10202,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -10187,7 +10212,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10195,7 +10220,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-data-descriptor": {
@@ -10203,7 +10228,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-descriptor": {
@@ -10211,9 +10236,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               },
               "dependencies": {
                 "kind-of": {
@@ -10230,7 +10255,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -10245,8 +10270,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "object.pick": {
@@ -10254,7 +10279,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -10269,7 +10294,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -10277,8 +10302,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -10291,9 +10316,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -10306,7 +10331,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -10314,7 +10339,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -10327,10 +10352,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -10338,7 +10363,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "pascalcase": {
@@ -10351,7 +10376,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -10374,9 +10399,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -10394,7 +10419,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -10402,7 +10427,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -10410,8 +10435,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -10436,8 +10461,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -10445,7 +10470,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10453,7 +10478,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10463,7 +10488,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -10473,9 +10498,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10483,8 +10508,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -10492,8 +10517,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -10508,7 +10533,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "regex-not": {
@@ -10516,8 +10541,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "remove-trailing-separator": {
@@ -10540,7 +10565,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -10574,7 +10599,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -10582,7 +10607,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-regex": {
@@ -10590,7 +10615,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "semver": {
@@ -10608,10 +10633,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10619,7 +10644,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10629,7 +10654,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -10652,14 +10677,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.1",
-            "use": "3.1.0"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -10667,7 +10692,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -10675,7 +10700,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10683,7 +10708,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10691,7 +10716,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10701,7 +10726,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10709,7 +10734,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10719,9 +10744,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -10736,9 +10761,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10746,7 +10771,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "isobject": {
@@ -10761,7 +10786,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           }
         },
         "source-map": {
@@ -10774,11 +10799,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.0.3",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-url": {
@@ -10791,12 +10816,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -10804,8 +10829,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -10818,8 +10843,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -10832,7 +10857,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "static-extend": {
@@ -10840,8 +10865,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -10849,7 +10874,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10857,7 +10882,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10865,7 +10890,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10875,7 +10900,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10883,7 +10908,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10893,9 +10918,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -10910,8 +10935,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10924,7 +10949,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -10934,7 +10959,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -10942,7 +10967,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -10960,11 +10985,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "3.1.9",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -10982,18 +11007,18 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "kind-of": "6.0.2",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -11001,7 +11026,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "extend-shallow": {
@@ -11009,7 +11034,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -11019,13 +11044,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -11033,7 +11058,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "extend-shallow": {
@@ -11041,7 +11066,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 },
                 "is-descriptor": {
@@ -11049,9 +11074,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "0.1.6",
-                    "is-data-descriptor": "0.1.4",
-                    "kind-of": "5.1.0"
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
                   }
                 },
                 "kind-of": {
@@ -11066,14 +11091,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -11081,7 +11106,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "extend-shallow": {
@@ -11089,7 +11114,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -11099,10 +11124,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -11110,7 +11135,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -11120,7 +11145,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -11128,7 +11153,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -11138,7 +11163,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -11146,7 +11171,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -11156,7 +11181,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -11164,7 +11189,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -11184,19 +11209,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.1",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               }
             }
           }
@@ -11211,7 +11236,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "to-regex": {
@@ -11219,10 +11244,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "to-regex-range": {
@@ -11230,8 +11255,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           },
           "dependencies": {
             "is-number": {
@@ -11239,7 +11264,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             }
           }
@@ -11255,9 +11280,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -11266,9 +11291,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -11285,10 +11310,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -11296,7 +11321,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "set-value": {
@@ -11304,10 +11329,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
               }
             }
           }
@@ -11317,8 +11342,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
@@ -11326,9 +11351,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -11363,7 +11388,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11378,8 +11403,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "which": {
@@ -11387,7 +11412,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -11411,8 +11436,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -11420,7 +11445,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -11428,9 +11453,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11445,9 +11470,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -11465,18 +11490,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -11494,9 +11519,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "strip-ansi": {
@@ -11504,7 +11529,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             },
             "yargs-parser": {
@@ -11512,7 +11537,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               }
             }
           }
@@ -11522,7 +11547,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -11557,8 +11582,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -11574,7 +11599,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -11583,7 +11608,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optionator": {
@@ -11592,12 +11617,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -11618,9 +11643,9 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
       }
     },
     "parse-glob": {
@@ -11630,10 +11655,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parseurl": {
@@ -11693,7 +11718,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -11737,7 +11762,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "propagate": {
@@ -11751,7 +11776,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -11761,9 +11786,9 @@
       "integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
       "dev": true,
       "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.5.0"
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.5.0"
       }
     },
     "pseudomap": {
@@ -11776,8 +11801,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -11785,9 +11810,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
       "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "requires": {
-        "duplexify": "3.5.4",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -11800,7 +11825,7 @@
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
       "requires": {
-        "bitcoin-ops": "1.4.1"
+        "bitcoin-ops": "^1.3.0"
       }
     },
     "qs": {
@@ -11813,8 +11838,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -11829,8 +11854,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -11840,7 +11865,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11850,7 +11875,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -11862,7 +11887,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11872,7 +11897,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -11904,7 +11929,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -11924,12 +11949,12 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "0.10.31",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -11939,10 +11964,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.0.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       },
       "dependencies": {
         "minimatch": {
@@ -11952,7 +11977,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -11975,9 +12000,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -11987,7 +12012,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpp": {
@@ -12002,9 +12027,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -12019,7 +12044,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -12055,7 +12080,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -12063,28 +12088,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "extend": {
@@ -12100,8 +12125,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -12110,7 +12135,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -12125,8 +12150,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "resumer": {
@@ -12135,7 +12160,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "retry-axios": {
@@ -12148,8 +12173,8 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "requires": {
-        "request": "2.83.0",
-        "through2": "2.0.3"
+        "request": "^2.81.0",
+        "through2": "^2.0.0"
       }
     },
     "rimraf": {
@@ -12158,7 +12183,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -12167,12 +12192,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -12181,7 +12206,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -12191,8 +12216,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -12200,7 +12225,7 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
           "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
           }
         }
       }
@@ -12211,7 +12236,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -12226,7 +12251,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -12249,7 +12274,7 @@
       "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-1.6.8.tgz",
       "integrity": "sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=",
       "requires": {
-        "async": "1.5.2"
+        "async": "^1.5.0"
       }
     },
     "semver": {
@@ -12264,18 +12289,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -12290,9 +12315,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -12313,8 +12338,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -12323,7 +12348,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -12349,7 +12374,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "snakeize": {
@@ -12362,7 +12387,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -12377,7 +12402,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "split-array-stream": {
@@ -12385,8 +12410,8 @@
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
-        "async": "2.6.0",
-        "is-stream-ended": "0.1.4"
+        "async": "^2.4.0",
+        "is-stream-ended": "^0.1.0"
       },
       "dependencies": {
         "async": {
@@ -12394,7 +12419,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -12409,14 +12434,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -12434,7 +12459,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
       "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
-        "stubs": "3.0.0"
+        "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
@@ -12458,8 +12483,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12474,7 +12499,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12485,9 +12510,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -12522,16 +12547,16 @@
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.2",
-        "formidable": "1.2.1",
-        "methods": "1.1.2",
-        "mime": "1.4.1",
-        "qs": "6.5.1",
-        "readable-stream": "2.0.6"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "debug": {
@@ -12557,8 +12582,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.2"
+        "methods": "~1.1.2",
+        "superagent": "^3.0.0"
       }
     },
     "supports-color": {
@@ -12573,12 +12598,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.0",
-        "lodash": "4.17.5",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12587,7 +12612,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12596,9 +12621,9 @@
           "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -12607,7 +12632,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12618,19 +12643,19 @@
       "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.5.0",
-        "resolve": "1.5.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.5.0",
+        "resolve": "~1.5.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "deep-equal": {
@@ -12651,12 +12676,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -12665,7 +12690,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -12699,8 +12724,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -12713,13 +12738,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -12727,7 +12752,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12738,7 +12763,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -12752,7 +12777,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -12773,7 +12798,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12788,7 +12813,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -12803,7 +12828,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -12826,7 +12851,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unpipe": {
@@ -12839,7 +12864,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -12885,7 +12910,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "user-home": "^1.1.1"
       }
     },
     "validator": {
@@ -12898,7 +12923,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "vary": {
@@ -12911,9 +12936,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "whatwg-fetch": {
@@ -12927,7 +12952,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wif": {
@@ -12935,7 +12960,7 @@
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
-        "bs58check": "2.1.1"
+        "bs58check": "<3.0.0"
       }
     },
     "winston": {
@@ -12943,12 +12968,12 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
       "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -12975,7 +13000,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -12983,9 +13008,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -12998,8 +13023,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -13007,7 +13032,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.0.0"
       }
     },
     "xtend": {

--- a/hub/package.json
+++ b/hub/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-flowtype": "^2.46.3",
     "fetch-mock": "^6.4.2",
     "flow-bin": "^0.71.0",
-    "mocha": "^3.5.3",
     "nock": "^9.1.9",
     "nyc": "^11.4.1",
     "proxyquire": "^2.0.1",

--- a/hub/package.json
+++ b/hub/package.json
@@ -15,6 +15,7 @@
     "blockstack": "^17.2.0",
     "body-parser": "^1.18.1",
     "cors": "^2.8.4",
+    "dropbox": "^4.0.7",
     "express": "^4.15.4",
     "express-winston": "^2.4.0",
     "jsontokens": "^0.7.7",

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -166,7 +166,7 @@ export function getChallengeText(myURL: string = DEFAULT_STORAGE_URL) {
 }
 
 export function parseAuthHeader(authHeader: string) {
-  if (!authHeader.startsWith('bearer')) {
+  if (!authHeader || !authHeader.startsWith('bearer')) {
     throw new ValidationError('Failed to parse authentication header.')
   }
   const authPart = authHeader.slice('bearer '.length)

--- a/hub/src/server/driverModel.js
+++ b/hub/src/server/driverModel.js
@@ -7,4 +7,6 @@ export interface DriverModel {
                        stream: Readable,
                        contentLength: number,
                        contentType: string }): Promise<string>;
+  performRead(args: { path: string,
+                      storageTopLevel: string }): Promise<any>;
 }

--- a/hub/src/server/driverModel.js
+++ b/hub/src/server/driverModel.js
@@ -8,5 +8,5 @@ export interface DriverModel {
                        contentLength: number,
                        contentType: string }): Promise<string>;
   performRead(args: { path: string,
-                      storageTopLevel: string }): Promise<any>;
+                      storageTopLevel: string }): Promise<Buffer>;
 }

--- a/hub/src/server/drivers/DBXDriver.js
+++ b/hub/src/server/drivers/DBXDriver.js
@@ -1,0 +1,92 @@
+/* @flow */
+
+import type { DriverModel } from '../driverModel'
+import { Dropbox } from 'dropbox'
+import { Readable } from 'stream'
+import { BadPathError } from '../errors'
+
+type DBX_CONFIG_TYPE = {
+  accessToken: string,
+  storageRootDirectory: string,
+  readURL?: string
+}
+
+class DBXDriver implements DriverModel {
+  dbx: Dropbox
+  overwrite: ?Boolean
+  storageRootDirectory: ?string
+
+  constructor (config: DBX_CONFIG_TYPE) {
+    const {accessToken, storageRootDirectory, overwrite} = config.dropbox
+    this.overwrite = overwrite || false
+    this.dbx = new Dropbox({accessToken})
+
+    if (!accessToken) {
+      throw new Error('Config is missing accessToken')
+    }
+
+    if (storageRootDirectory) {
+      if (DBXDriver.isPathValid(storageRootDirectory)) {
+        throw new BadPathError('Invalid Path')
+      }
+
+      this.storageRootDirectory = storageRootDirectory
+
+      if (!this.storageRootDirectory.startsWith('/')) {
+        this.storageRootDirectory = `/${this.storageRootDirectory}`
+      }
+    } else {
+      this.storageRootDirectory = '/'
+    }
+
+    this.readURL = config.readURL
+  }
+
+  static isPathValid (path: string) {
+    if (path.indexOf('..') !== -1) {
+      return false
+    }
+    return path.slice(-1) !== '/'
+  }
+
+  getReadURLPrefix (): string {
+    //TODO (djs): check how to return file/content
+    return `https://www.dropbox.com/home`
+  }
+
+  performWrite (args: {
+    path: string,
+    storageTopLevel: string,
+    stream: Readable,
+    contentLength: number,
+    contentType: string
+  }): Promise<string> {
+    const {stream, path, storageTopLevel} = args
+    const directoryPath = `${this.storageRootDirectory}${storageTopLevel}/${path}`
+
+    return new Promise((resolve, reject) => {
+      const dbxParams = {
+        contents: stream,
+        path: directoryPath
+      }
+
+      if (this.overwrite) {
+        dbxParams.mode = 'overwrite'
+      } else {
+        dbxParams.autorename = true
+      }
+
+      this.dbx.filesUpload(dbxParams)
+        .then(data => {
+          return resolve(data.path_display)
+        })
+        .catch(err => {
+          return reject(new Error('Dropbox storage failure: failed to store file ' +
+            `${path} in ${directoryPath}: ${JSON.stringify(err)}`))
+        })
+    })
+  }
+}
+
+module.exports = DBXDriver
+

--- a/hub/src/server/drivers/DBXDriver.js
+++ b/hub/src/server/drivers/DBXDriver.js
@@ -50,8 +50,23 @@ class DBXDriver implements DriverModel {
   }
 
   getReadURLPrefix (): string {
-    //TODO (djs): check how to return file/content
-    return `https://www.dropbox.com/home`
+    return `https://${this.readURL}/`
+  }
+
+  performRead (args: { path: string, storageTopLevel: string }) {
+    const {path, storageTopLevel} = args
+    const filePath = `${this.storageRootDirectory}${storageTopLevel}/${path}`
+
+    return new Promise((resolve, reject) => {
+      this.dbx.filesDownload({path: filePath})
+        .then(file => {
+          return resolve(file.fileBinary.toString('utf-8'))
+        })
+        .catch(error => {
+          return reject(new Error('Dropbox storage failure: failed to read file ' +
+            `${path} in ${filePath}: ${JSON.stringify(error)}`))
+        })
+    })
   }
 
   performWrite (args: {

--- a/hub/src/server/drivers/DBXDriver.js
+++ b/hub/src/server/drivers/DBXDriver.js
@@ -76,6 +76,9 @@ class DBXDriver implements DriverModel {
         dbxParams.autorename = true
       }
 
+      // TODO (djs):
+      // Do not use this to upload a file larger than 150 MB.
+      // Instead, create an upload session with uploadSessionStart().
       this.dbx.filesUpload(dbxParams)
         .then(data => {
           return resolve(data.path_display)

--- a/hub/src/server/http.js
+++ b/hub/src/server/http.js
@@ -32,6 +32,9 @@ export function makeHttpServer(config: Object) {
   } else if (config.driver === 'google-cloud') {
     const GcDriver = require('./drivers/GcDriver')
     driver = new GcDriver(config)
+  } else if (config.driver === 'dropbox') {
+    const DBXDriver = require('./drivers/DBXDriver')
+    driver = new DBXDriver(config)
   } else if (config.driverClass) {
     driver = new config.driverClass(config)
   } else {

--- a/hub/src/server/server.js
+++ b/hub/src/server/server.js
@@ -50,11 +50,9 @@ export class HubServer {
       .then(() => this.driver.performWrite(writeCommand))
   }
 
-  handleGetFileRequest(address: string, path: string,
-                       requestHeaders: {'content-type': string,
-                                        'content-length': string,
-                                        'authorization': string},) {
-    this.validate(address, requestHeaders)
+  handleGetFileRequest(address: string, path: string) {
+    // TODO (djs): should think about authorization
+    // this.validate(address, requestHeaders)
     const readCommand = { storageTopLevel: address, path}
 
     return this.proofChecker.checkProofs(address, path)

--- a/hub/src/server/server.js
+++ b/hub/src/server/server.js
@@ -32,7 +32,7 @@ export class HubServer {
   handleRequest(address: string, path: string,
                 requestHeaders: {'content-type': string,
                                  'content-length': string,
-                                 authorization: string},
+                                 'authorization': string},
                 stream: Readable) {
     this.validate(address, requestHeaders)
 
@@ -48,5 +48,16 @@ export class HubServer {
 
     return this.proofChecker.checkProofs(address, path)
       .then(() => this.driver.performWrite(writeCommand))
+  }
+
+  handleGetFileRequest(address: string, path: string,
+                       requestHeaders: {'content-type': string,
+                                        'content-length': string,
+                                        'authorization': string},) {
+    this.validate(address, requestHeaders)
+    const readCommand = { storageTopLevel: address, path}
+
+    return this.proofChecker.checkProofs(address, path)
+      .then(() => this.driver.performRead(readCommand))
   }
 }


### PR DESCRIPTION
This pull request will allow users to use Dropbox as a storage.

In order to enable this driver edit your `config.json`:
```
"readURL": "<required>",
"driver": "dropbox",

...

"dropbox": {
    "accessToken": "<access token>",
    "storageRootDirectory": "<name of root directory (optional)>"
  },

...
```

