### PR TITLE
git@github.com: Permission denied

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -3,7 +3,7 @@
 To get started running a gaia hub, execute the following:
 
 ```bash
-$ git clone git@github.com:blockstack/gaia.git
+$ git clone https://github.com/blockstack/gaia.git
 $ cd gaia/hub/
 $ npm install
 $ cp ./config.sample.json ./config.json


### PR DESCRIPTION
possible fix for the following error while attempting to clone gaia with instructions from /hub/README.md

```
$ git clone git@github.com:blockstack/gaia.git
Cloning into 'gaia'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```