### PR TITLE
Fix list-files for disk

### DIFF
--- a/hub/.eslintrc
+++ b/hub/.eslintrc
@@ -25,6 +25,7 @@
     "prefer-const": 2,
     "new-cap": 0,
     "camelcase": 2,
+    "brace-style": 2,
     "semi": [2, "never"],
     "flowtype/define-flow-type": 1,
     "valid-jsdoc": ["error"]

--- a/hub/src/server/drivers/diskDriver.js
+++ b/hub/src/server/drivers/diskDriver.js
@@ -58,14 +58,12 @@ class DiskDriver implements DriverModel {
         if ((statInfo.mode & fs.constants.S_IFDIR) === 0) {
           throw new Error(`Not a directory: ${tmpPath}`)
         }
-      }
-      catch (e) {
+      } catch (e) {
         if (e.code === 'ENOENT') {
           // need to create
           logger.debug(`mkdir ${tmpPath}`)
           fs.mkdirSync(tmpPath)
-        }
-        else {
+        } else {
           throw e
         }
       }
@@ -88,25 +86,20 @@ class DiskDriver implements DriverModel {
         for (let j = 0; j < childNames.length; j++) {
           fileNames.push(childNames[j])
         }
-      }
-      else {
+      } else {
         fileNames.push(fileOrDir)
       }
     }
     return fileNames
   }
 
-  listFilesInDirectory(listPath: string, pageNum: number) {
-    const names = this.findAllFiles(listPath).map((fileName) => {
-      return fileName.slice(listPath.length + 1)
-    })
-    return Promise.resolve().then(() => {
-      const res = {
-        entries: names.slice(pageNum * this.pageSize, (pageNum + 1) * this.pageSize),
-        page: `${pageNum + 1}`
-      }
-      return res
-    })
+  listFilesInDirectory(listPath: string, pageNum: number) : Promise<{entries: Array<string>, page: ?string}> {
+    const names = this.findAllFiles(listPath).map(
+      (fileName) => fileName.slice(listPath.length + 1))
+    return Promise.resolve().then(() => ({
+      entries: names.slice(pageNum * this.pageSize, (pageNum + 1) * this.pageSize),
+      page: `${pageNum + 1}`
+    }))
   }
 
   listFiles(prefix: string, page: ?string) {
@@ -119,16 +112,14 @@ class DiskDriver implements DriverModel {
           throw new Error('Invalid page number')
         }
         pageNum = parseInt(page)
-      }
-      else {
+      } else {
         pageNum = 0
       }
       const stat = fs.statSync(listPath)
       if (!stat.isDirectory()) {
         throw new Error('Not a directory')
       }
-    }
-    catch(e) {
+    } catch(e) {
       throw new Error('Invalid arguments: invalid page or not a directory')
     }
 

--- a/hub/src/server/http.js
+++ b/hub/src/server/http.js
@@ -81,31 +81,30 @@ export function makeHttpServer(config: Object) {
 
   app.post(
       /^\/list-files\/([a-zA-Z0-9]+)\/?/, express.json(),
-    (req: express.request, res: express.response) =>
-      {
-        // sanity check...
-        if (req.headers['content-length'] > 4096) {
-          writeResponse(res, { mesasge: 'Invalid JSON: too long'}, 400)
-          return
-        }
+    (req: express.request, res: express.response) => {
+      // sanity check...
+      if (req.headers['content-length'] > 4096) {
+        writeResponse(res, { mesasge: 'Invalid JSON: too long'}, 400)
+        return
+      }
 
-        const address = req.params[0]
-        const requestBody = req.body
-        const page = requestBody.page ? requestBody.page : null
+      const address = req.params[0]
+      const requestBody = req.body
+      const page = requestBody.page ? requestBody.page : null
 
-        server.handleListFiles(address, page, req.headers)
-          .then((files) => {
-            writeResponse(res, { entries: files.entries, page: files.page }, 202)
-          })
-          .catch((err) => {
-            logger.error(err)
-            if (err.name === 'ValidationError') {
-              writeResponse(res, { message: err.message }, 401)
-            } else {
-              writeResponse(res, { message: 'Server Error' }, 500)
-            }
-          })
-      })
+      server.handleListFiles(address, page, req.headers)
+        .then((files) => {
+          writeResponse(res, { entries: files.entries, page: files.page }, 202)
+        })
+        .catch((err) => {
+          logger.error(err)
+          if (err.name === 'ValidationError') {
+            writeResponse(res, { message: err.message }, 401)
+          } else {
+            writeResponse(res, { message: 'Server Error' }, 500)
+          }
+        })
+    })
 
   app.get('/hub_info/', (req: express.request,
                          res: express.response) => {

--- a/hub/test/test.js
+++ b/hub/test/test.js
@@ -494,7 +494,7 @@ function testDiskDriver() {
       .then(() => t.ok(false, 'Should have thrown'))
       .catch((err) => t.equal(err.message, 'Invalid Path', 'Should throw bad path'))
       .then(() => driver.performWrite(
-        { path: 'foo.txt',
+        { path: 'foo/bar.txt',
           storageTopLevel: '12345',
           stream: s,
           contentType: 'application/octet-stream',
@@ -505,7 +505,7 @@ function testDiskDriver() {
       .then(() => driver.listFiles('12345'))
       .then((files) => {
         t.equal(files.entries.length, 1, 'Should return one file')
-        t.equal(files.entries[0], 'foo.txt', 'Should be foo.txt!')
+        t.equal(files.entries[0], 'foo/bar.txt', 'Should be foo.txt!')
       })
   })
 }


### PR DESCRIPTION
Fix the list-files implementation for the disk driver so it lists all files (like `find`), not just only the top-level directories.  This makes it consistent with the rest of the drivers on list-files.  Update the tests to test this new behavior.