### PR TITLE
Return an empty response if the directory or file does not exist

### DIFF
--- a/hub/src/server/drivers/diskDriver.js
+++ b/hub/src/server/drivers/diskDriver.js
@@ -106,6 +106,16 @@ class DiskDriver implements DriverModel {
     // returns {'entries': [...], 'page': next_page}
     let pageNum
     const listPath = `${this.storageRootDirectory}/${prefix}`
+    const emptyResponse = {
+      entries: [],
+      page: page + 1
+    }
+
+    if (!fs.exists(listPath)) {
+      // nope 
+      return Promise.resolve().then(() => emptyResponse)
+    }
+      
     try {
       if (page) {
         if (!page.match(/^[0-9]+$/)) {
@@ -117,7 +127,8 @@ class DiskDriver implements DriverModel {
       }
       const stat = fs.statSync(listPath)
       if (!stat.isDirectory()) {
-        throw new Error('Not a directory')
+        // nope 
+        return Promise.resolve().then(() => emptyResponse)
       }
     } catch(e) {
       throw new Error('Invalid arguments: invalid page or not a directory')

--- a/hub/src/server/drivers/diskDriver.js
+++ b/hub/src/server/drivers/diskDriver.js
@@ -108,7 +108,7 @@ class DiskDriver implements DriverModel {
     const listPath = `${this.storageRootDirectory}/${prefix}`
     const emptyResponse = {
       entries: [],
-      page: page + 1
+      page: `${page + 1}`
     }
 
     if (!fs.exists(listPath)) {


### PR DESCRIPTION
On `list-files`, have the disk driver return `{ entries: [], page: 1 }` (or whatever `page + 1` is) in the event that the directory being listed does not exist or the path is not a directory.  Before, this would throw an exception on the server.