### PR TITLE
Hotfix for loose casing in bearer prefix

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1]
+### Changes
+- Allow multiple cases in "bearer" authentication prefix.
+
 ## [2.2.0]
 ### Added
 - Option for requiring that a client supply a `hubURL` claim in their

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -264,7 +264,7 @@ export function getChallengeText(myURL: string = DEFAULT_STORAGE_URL) {
 }
 
 export function parseAuthHeader(authHeader: string) {
-  if (!authHeader.startsWith('bearer')) {
+  if (!authHeader || !authHeader.toLowerCase().startsWith('bearer')) {
     throw new ValidationError('Failed to parse authentication header.')
   }
   const authPart = authHeader.slice('bearer '.length)

--- a/hub/test/test.js
+++ b/hub/test/test.js
@@ -211,6 +211,22 @@ function testAuth() {
     t.end()
   })
 
+  test('authentication legacy/regression with multi-case bearer', (t) => {
+    const legacyPart = {
+      wif: 'Kzp44Hhp6SFUXMuMi6MUDTqyfcNyyjntrphEHVMsiitRrjMyoV4p',
+      addr: '1AotVNASQouiNiBtfxv49WWvSNcQUzGYuU',
+      serverName: 'storage.blockstack.org',
+      legacyAuth: 'eyJwdWJsaWNrZXkiOiIwMjQxYTViMDQ2Mjg1ZjVlMjgwMDRmOTJjY2M0MjNmY2RkODYyZmYzY' +
+        'jgwODUwNzE4MDY4MGIyNDA3ZTIyOWE3NzgiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDY5ODUwNmNjYjg3MDg1Zm' +
+        'Y5ZGI3ZTc4MTIwYTVmMjY1YzExZmY0ODc4OTBlNDQ1MWZjYWM3NjA4NTkyMDhjZWMwMjIwNTZkY2I0OGUyYzE' +
+        '4Y2YwZjQ1NDZiMmQ3M2I2MDY4MWM5ODEyMzQyMmIzOTRlZjRkMWI2MjE3NTYyODQ4MzUwNCJ9' }
+    t.doesNotThrow(() => auth.validateAuthorizationHeader(`BeArEr ${legacyPart.legacyAuth}`,
+                                                          legacyPart.serverName,
+                                                          legacyPart.addr),
+                   'legacy authentication token should work')
+    t.end()
+  })
+
   test('storage validation', (t) => {
     const challengeText = auth.getChallengeText()
     const authPart = auth.LegacyAuthentication.makeAuthPart(testPairs[0], challengeText)


### PR DESCRIPTION
See issue #147 --

Simple patch to allow loose casing in the bearer prefix for authentication headers.