### PR TITLE
allow case-insensitive 'Bearer' auth header

### DIFF
--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -330,7 +330,7 @@ export function getChallengeText(myURL: string = DEFAULT_STORAGE_URL) {
 }
 
 export function parseAuthHeader(authHeader: string) {
-  if (!authHeader.startsWith('bearer')) {
+  if (!authHeader.toLowerCase().startsWith('bearer')) {
     throw new ValidationError('Failed to parse authentication header.')
   }
   const authPart = authHeader.slice('bearer '.length)

--- a/hub/test/test.js
+++ b/hub/test/test.js
@@ -208,6 +208,10 @@ function testAuth() {
                                                           legacyPart.serverName,
                                                           legacyPart.addr),
                    'legacy authentication token should work')
+    t.doesNotThrow(() => auth.validateAuthorizationHeader(`Bearer ${legacyPart.legacyAuth}`,
+      legacyPart.serverName,
+      legacyPart.addr),
+      'legacy authentication token should work with capitalized "Bearer"')
     t.end()
   })
 


### PR DESCRIPTION
Would fix https://github.com/blockstack/blockstack.js/issues/544