### PR TITLE
Hotfix/disk content type

### DIFF
--- a/hub/src/server/errors.js
+++ b/hub/src/server/errors.js
@@ -21,4 +21,10 @@ export class NotEnoughProofError {
   }
 }
 
-
+export class InvalidInputError {
+  constructor (message) {
+    this.name = 'InvalidInputError'
+    this.message = message
+    this.stack = (new Error(message)).stack
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "node": "8.1.x"
   },
   "scripts": {
-    "postinstall": "NODE_ENV=development npm install --prefix hub"
+    "postinstall": "NODE_ENV=development npm install --prefix hub && NODE_ENV=development npm install --prefix reader"
   }
 }

--- a/reader/.babelrc
+++ b/reader/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "flow"]
+}

--- a/reader/.eslintrc
+++ b/reader/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "parser": "babel-eslint",
+  "plugins": ["flowtype"],
+  "env": {
+    "browser": false,
+    "es6": true,
+    "node": true,
+  },
+  "rules": {
+    "comma-dangle": ["error", "never"],
+    "quotes": [2, "single"],
+    "eol-last": 2,
+    "no-debugger": 1,
+    "no-mixed-requires": 0,
+    "no-underscore-dangle": 0,
+    "no-multi-spaces": 0,
+    "no-trailing-spaces": 0,
+    "no-extra-boolean-cast": 0,
+    "no-undef": 2,
+    "no-unused-vars": 2,
+    "no-var": 2,
+    "no-param-reassign": 0,
+    "no-else-return": 0,
+    "no-console": 0,
+    "prefer-const": 2,
+    "new-cap": 0,
+    "camelcase": 2,
+    "brace-style": 2,
+    "semi": [2, "never"],
+    "flowtype/define-flow-type": 1,
+    "valid-jsdoc": ["error"]
+  }
+}

--- a/reader/.flowconfig
+++ b/reader/.flowconfig
@@ -1,0 +1,12 @@
+[ignore]
+.*/node_modules/documentation/*
+.*/node_modules/.staging/*
+.*/node_modules/npm/*
+
+[include]
+
+[libs]
+
+[options]
+
+[lints]

--- a/reader/package.json
+++ b/reader/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "gaia-reader",
+  "version": "2.2.1",
+  "description": "",
+  "main": "index.js",
+  "engines": {
+    "node": "^8"
+  },
+  "dependencies": {
+    "body-parser": "^1.18.1",
+    "cors": "^2.8.4",
+    "express": "^4.15.4",
+    "express-winston": "^2.4.0",
+    "node-fetch": "^2.0.0",
+    "winston": "^2.3.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.2.2",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-flow": "^6.23.0",
+    "eslint": "^4.18.1",
+    "eslint-plugin-flowtype": "^2.46.3",
+    "fetch-mock": "^6.4.2",
+    "flow-bin": "^0.71.0",
+    "nock": "^9.1.9",
+    "nyc": "^13.0.0",
+    "proxyquire": "^2.0.1",
+    "supertest": "^3.0.0",
+    "tape": "^4.9.0"
+  },
+  "bin": {
+    "blockstack-gaia-reader": "./lib/index.js"
+  },
+  "scripts": {
+    "start": "npm run build && node lib/index.js",
+    "build": "npm run lint && babel src -d lib && chmod +x lib/index.js",
+    "flow": "flow",
+    "lint": "eslint src",
+    "test-inner": "npm run build && npm run flow && node ./test/test.js",
+    "test": "nyc --reporter=text npm run test-inner"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blockstack/gaia.git"
+  },
+  "authors": [
+    "Aaron Blankstein (aaron@blockstack.com)",
+    "Jude Nelson (jude@blockstack.com)"
+  ]
+}

--- a/reader/src/config.js
+++ b/reader/src/config.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import winston from 'winston'
+import fs from 'fs'
+import process from 'process'
+
+const configDefaults = {
+  argsTransport: {
+    level: 'debug',
+    handleExceptions: true,
+    timestamp: true,
+    stringify: true,
+    colorize: true,
+    json: true
+  },
+  regtest: false,
+  testnet: false,
+  port: 8008,
+  storageRootDirectory: '/tmp/gaia-disk'
+}
+
+export function getConfig() {
+  const configPath = process.env.CONFIG_PATH || process.argv[2] || './config.json'
+  let config
+  try {
+    config = Object.assign(
+      {}, configDefaults, JSON.parse(fs.readFileSync(configPath).toString()))
+  } catch (e) {
+    config = Object.assign({}, configDefaults)
+  }
+
+  winston.configure({ transports: [
+    new winston.transports.Console(config.argsTransport) ] })
+
+  return config
+}
+

--- a/reader/src/config.js
+++ b/reader/src/config.js
@@ -16,7 +16,9 @@ const configDefaults = {
   regtest: false,
   testnet: false,
   port: 8008,
-  storageRootDirectory: '/tmp/gaia-disk'
+  diskSettings: {
+    storageRootDirectory: '/tmp/gaia-disk'
+  }
 }
 
 export function getConfig() {

--- a/reader/src/http.js
+++ b/reader/src/http.js
@@ -1,0 +1,54 @@
+/* @flow */
+
+import express from 'express'
+import expressWinston from 'express-winston'
+import logger from 'winston'
+import cors from 'cors'
+import Path from 'path'
+
+import { 
+  GaiaDiskReader
+} from './server'
+
+export function makeHttpServer(config: Object) {
+  const app = express()
+  const server = new GaiaDiskReader()
+
+  app.config = config
+
+  app.use(expressWinston.logger({
+    transports: logger.loggers.default.transports }))
+
+  app.use(cors())
+
+  app.get(/\/([a-zA-Z0-9]+)\/(.+)/, (req: express.request, res: express.response) => {
+    let filename = req.params[1]
+    if (filename.endsWith('/')) {
+      filename = filename.substring(0, filename.length - 1)
+    }
+    const address = req.params[0]
+
+    return server.handleGet(config.storageRootDirectory, address, filename)
+      .then((fileInfo) => {
+        const exists = fileInfo.exists
+        const contentType = fileInfo.contentType
+
+        if (!exists) {
+          return res.status(404).send('File not found')
+        }
+
+        const opts = {
+          root: config.storageRootDirectory,
+          headers: {
+            'content-type': contentType
+          }
+        }
+        const path = Path.join(address, filename)
+
+        return res.sendFile(path, opts)
+      })
+  })
+
+  return app
+}
+

--- a/reader/src/index.js
+++ b/reader/src/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import winston from 'winston'
+import { makeHttpServer } from './http.js'
+import { getConfig } from './config.js'
+
+const conf = getConfig()
+const app = makeHttpServer(conf)
+
+app.listen(
+  app.config.port,
+  () => winston.warn(`server starting on port ${app.config.port} in ${app.settings.env} mode`))
+

--- a/reader/src/server.js
+++ b/reader/src/server.js
@@ -1,0 +1,33 @@
+/* @flow */
+
+import Path from 'path'
+import fs from 'fs'
+
+const METADATA_DIRNAME = '.gaia-metadata'
+
+export class GaiaDiskReader {
+
+  constructor() {
+  }
+
+  handleGet(storageRoot: string, topLevelDir: string, filename: string) : Promise<*> {
+    const filePath = Path.join(storageRoot, topLevelDir, filename)
+    try {
+      fs.statSync(filePath)
+    } catch (e) {
+      const ret = { exist: false, contentType: undefined }
+      return Promise.resolve().then(() => ret)
+    }
+
+    const metadataPath = Path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
+    try {
+      const metadataJSON = fs.readFileSync(metadataPath).toString()
+      const metadata = JSON.parse(metadataJSON)
+      const ret = { exists: true, contentType: metadata['content-type'] }
+      return Promise.resolve().then(() => ret)
+    } catch (e) {
+      const ret = { exists: true, contentType: 'application/octet-stream' }
+      return Promise.resolve().then(() => ret)
+    }
+  }
+}


### PR DESCRIPTION
This patch updates the disk driver to store the `content-type` header contents alongside any files, written into the directory whose path is `$storageRoot/.gaia-metadata/$address/$filename`.  This is important, because these metadata files will *not* be directly listable or writeable by remote clients.

This PR also adds a `reader/` sub-package that implements the read endpoint for the `disk` driver.  This is a necessary component because the read endpoint is aware of the disk driver's above scheme, and will supply the appropriate content-type header on `GET`.

When deploying a Gaia hub that uses the `disk` driver, it is recommended to run both the `blockstack-gaia-hub` process and the `blockstack-gaia-reader` process, with the `blockstack-gaia-reader` process running behind a "real" HTTP server like nginx.  The `blockstack-gaia-reader` process can read the same config file as the `blockstack-gaia-hub`, and will honor the `diskSettings.storageRootDirectory` field to find the top-level disk storage directory.