### PR TITLE
Fix reader bug with storageRootDirectory config key used for file GETs.

### DIFF
--- a/reader/src/http.js
+++ b/reader/src/http.js
@@ -38,7 +38,7 @@ export function makeHttpServer(config: Object) {
         }
 
         const opts = {
-          root: config.storageRootDirectory,
+          root: config.diskSettings.storageRootDirectory,
           headers: {
             'content-type': contentType
           }


### PR DESCRIPTION
Tagging @GInxh since this may be affecting work on the Gaia VMs. 