### PR TITLE
Fix disk driver bug with the recursive-mkdir function.

### DIFF
--- a/hub/package.json
+++ b/hub/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.4",
     "express": "^4.15.4",
     "express-winston": "^2.4.0",
+    "fs-extra": "^7.0.1",
     "jsontokens": "^0.7.8",
     "node-fetch": "^2.0.0",
     "winston": "^2.3.1"

--- a/hub/src/server/drivers/diskDriver.js
+++ b/hub/src/server/drivers/diskDriver.js
@@ -53,7 +53,15 @@ class DiskDriver implements DriverModel {
 
   mkdirs(path: string) {
     const normalizedPath = Path.normalize(path)
-    fs.ensureDirSync(normalizedPath)
+    // Check if directory exists.
+    if (!fs.existsSync(normalizedPath)) {
+      // If it doesn't, create it - this is done recursively similar to `mkdir -p`.
+      fs.ensureDirSync(normalizedPath)
+      logger.debug(`mkdir ${normalizedPath}`)
+    } else if (!fs.lstatSync(normalizedPath).isDirectory()) {
+      // Ensure path is a directory.
+      throw new Error(`Not a directory: ${normalizedPath}`)
+    }
   }
 
   findAllFiles(listPath: string) : Array<string> {

--- a/hub/src/server/drivers/diskDriver.js
+++ b/hub/src/server/drivers/diskDriver.js
@@ -1,5 +1,5 @@
 /* @flow */
-import fs from 'fs'
+import fs from 'fs-extra'
 import { BadPathError, InvalidInputError } from '../errors'
 import logger from 'winston'
 import Path from 'path'
@@ -52,28 +52,8 @@ class DiskDriver implements DriverModel {
   }
 
   mkdirs(path: string) {
-    const pathParts = path.replace(/^\//, '').split('/')
-    let tmpPath = '/'
-    for (let i = 0; i <= pathParts.length; i++) {
-      try {
-        const statInfo = fs.lstatSync(tmpPath)
-        if ((statInfo.mode & fs.constants.S_IFDIR) === 0) {
-          throw new Error(`Not a directory: ${tmpPath}`)
-        }
-      } catch (e) {
-        if (e.code === 'ENOENT') {
-          // need to create
-          logger.debug(`mkdir ${tmpPath}`)
-          fs.mkdirSync(tmpPath)
-        } else {
-          throw e
-        }
-      }
-      if (i === pathParts.length) {
-        break
-      }
-      tmpPath = `${tmpPath}/${pathParts[i]}`
-    }
+    const normalizedPath = Path.normalize(path)
+    fs.ensureDirSync(normalizedPath)
   }
 
   findAllFiles(listPath: string) : Array<string> {


### PR DESCRIPTION
When specifying an absolute path like `/tmp/gaia` the function that ensures the directory exists (mimicking `mkdir -p`) was failing on MacOS. Looks like it was doing an lstat on the path `/` and ending up trying to create a path like `//tmp/gaia`. This may have been working on linux - not sure.

Replaced the function with the popular `fs-extra` lib which includes a cross platform mkdirp/ensureDir.

