### PR TITLE
Hotfix/Use correct logger in express-winston

### DIFF
--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/http.js
+++ b/hub/src/server/http.js
@@ -29,7 +29,7 @@ export function makeHttpServer(config: Object) {
 
   // Instantiate server logging with Winston
   app.use(expressWinston.logger({
-    transports: logger.loggers.default.transports }))
+    winstonInstance: logger }))
 
   app.use(cors())
 


### PR DESCRIPTION
This fixes an issue where the express logger wasn't picking up the formatting changes from the config file correctly.