### PR TITLE
Deprecate timestamps

### DIFF
--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.2.2",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -252,9 +252,6 @@ export class V1Authentication {
     }
 
     if (!challengeTexts.includes(gaiaChallenge)) {
-      console.log(challengeTexts)
-      console.log(gaiaChallenge)
-      console.log(challengeTexts.includes(gaiaChallenge))
       throw new ValidationError(`Invalid gaiaChallenge text in supplied JWT: "${gaiaChallenge}"` +
                                 ` not found in ${JSON.stringify(challengeTexts)}`)
     }

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -78,7 +78,7 @@ export class V1Authentication {
     return `v1:${token}`
   }
 
-  static makeAssociationToken(secretKey: bitcoin.ECPair, childPublicKey: string) { 
+  static makeAssociationToken(secretKey: bitcoin.ECPair, childPublicKey: string) {
     const FOUR_MONTH_SECONDS = 60 * 60 * 24 * 31 * 4
     const publicKeyHex = secretKey.getPublicKeyBuffer().toString('hex')
     const salt = crypto.randomBytes(16).toString('hex')
@@ -164,7 +164,7 @@ export class V1Authentication {
     }
 
     if (!decodedToken.payload.hasOwnProperty('scopes')) {
-      // not given 
+      // not given
       return []
     }
 
@@ -195,7 +195,7 @@ export class V1Authentication {
    *
    * this throws a ValidationError if the authentication is invalid
    */
-  isAuthenticationValid(address: string, challengeText: string,
+  isAuthenticationValid(address: string, challengeTexts: Array<string>,
                         options?: { requireCorrectHubUrl?: boolean,
                                     validHubUrls?: Array<string> }) : string {
     let decodedToken
@@ -251,8 +251,12 @@ export class V1Authentication {
       throw new ValidationError('Failed to verify supplied authentication JWT')
     }
 
-    if (gaiaChallenge !== challengeText) {
-      throw new ValidationError(`Invalid gaiaChallenge text in supplied JWT: ${gaiaChallenge}`)
+    if (!challengeTexts.includes(gaiaChallenge)) {
+      console.log(challengeTexts)
+      console.log(gaiaChallenge)
+      console.log(challengeTexts.includes(gaiaChallenge))
+      throw new ValidationError(`Invalid gaiaChallenge text in supplied JWT: "${gaiaChallenge}"` +
+                                ` not found in ${JSON.stringify(challengeTexts)}`)
     }
 
     const expiresAt = decodedToken.payload.exp
@@ -302,42 +306,39 @@ export class LegacyAuthentication {
     return []
   }
 
-  isAuthenticationValid(address: string, challengeText: string,
+  isAuthenticationValid(address: string, challengeTexts: Array<string>,
                         options? : {}) { //  eslint-disable-line no-unused-vars
     if (this.publickey.getAddress() !== address) {
       throw new ValidationError('Address not allowed to write on this path')
     }
 
-    const digest = bitcoin.crypto.sha256(challengeText)
-    const valid = (this.publickey.verify(digest, this.signature) === true)
+    for (const challengeText of challengeTexts) {
+      const digest = bitcoin.crypto.sha256(challengeText)
+      const valid = (this.publickey.verify(digest, this.signature) === true)
 
-    if (!valid) {
-      logger.debug(`Failed to validate with challenge text: ${challengeText}`)
-      throw new ValidationError('Invalid signature or expired authentication token.')
+      if (valid) {
+        return address
+      }
     }
-    return address
+    logger.debug(`Failed to validate with challenge text: ${JSON.stringify(challengeTexts)}`)
+    throw new ValidationError('Invalid signature or expired authentication token.')
   }
 }
 
 export function getChallengeText(myURL: string = DEFAULT_STORAGE_URL) {
   const header = 'gaiahub'
-  const dateParts = new Date().toISOString().split('T')[0]
-        .split('-')
-  // for right now, access tokens are valid for the calendar year.
-  const allowedSpan = dateParts[0]
+  const allowedSpan = '0'
   const myChallenge = 'blockstack_storage_please_sign'
   return JSON.stringify( [header, allowedSpan, myURL, myChallenge] )
 }
 
-export function getChallengeTexts(myURL: string = DEFAULT_STORAGE_URL) {
-  const curChallengeText = getChallengeText(myURL)
-  
-  // make previous year's challenge text
+export function getLegacyChallengeTexts(myURL: string = DEFAULT_STORAGE_URL): Array<string> {
+  // make legacy challenge texts
   const header = 'gaiahub'
   const myChallenge = 'blockstack_storage_please_sign'
-  const prevChallengeText = JSON.stringify( [header, '2018', myURL, myChallenge] )
-
-  return [curChallengeText, prevChallengeText]
+  const legacyYears = ['2018', '2019']
+  return legacyYears.map(year => JSON.stringify(
+    [header, year, myURL, myChallenge]))
 }
 
 export function parseAuthHeader(authHeader: string) {
@@ -380,24 +381,11 @@ export function validateAuthorizationHeader(authHeader: string, serverName: stri
     throw new ValidationError('Failed to parse authentication header.')
   }
 
-  const challengeTexts = getChallengeTexts(serverName)
-  for (let i = 0; i < challengeTexts.length; i++) {
-    try {
-      const valid = authObject.isAuthenticationValid(address, challengeTexts[i], 
-        { validHubUrls, requireCorrectHubUrl })
+  const challengeTexts = []
+  challengeTexts.push(getChallengeText(serverName))
+  getLegacyChallengeTexts(serverName).forEach(challengeText => challengeTexts.push(challengeText))
 
-      if (valid) {
-        return valid
-      }
-    } catch (err) {
-      if (err instanceof ValidationError) {
-        continue
-      } else {
-        throw err
-      }
-    }
-  }
-  throw new ValidationError('Invalid gaiaChallenge text in supplied JWT')
+  return authObject.isAuthenticationValid(address, challengeTexts, { validHubUrls, requireCorrectHubUrl })
 }
 
 
@@ -428,13 +416,13 @@ function validateScopes(scopes: Array<AuthScopeType>) {
 
   for (let i = 0; i < scopes.length; i++) {
     const scope = scopes[i]
-    
+
     // valid scope?
     const found = AuthScopes.find((s) => (s === scope.scope))
     if (!found) {
       throw new ValidationError(`Unrecognized scope ${scope.scope}`)
     }
   }
-  
+
   return true
 }

--- a/hub/test/src/testAuth.js
+++ b/hub/test/src/testAuth.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import bitcoin from 'bitcoinjs-lib'
 import test  from 'tape'
 import { TokenSigner } from 'jsontokens'
@@ -46,17 +48,17 @@ export function testAuth() {
     const authPart = auth.LegacyAuthentication.makeAuthPart(testPairs[0], challengeText)
     const authorization = `bearer ${authPart}`
     const authenticator = auth.parseAuthHeader(authorization)
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong address must throw')
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], 'potatos'),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], ['potatos']),
              errors.ValidationError, 'Wrong challenge text must throw')
-    t.ok(authenticator.isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]),
          'Good signature must pass')
 
     const pkBad = bitcoin.ECPair.fromPublicKeyBuffer(testPairs[1].getPublicKeyBuffer())
     const authBad = new auth.LegacyAuthentication(pkBad, authenticator.signature)
 
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              'Bad signature must throw')
     t.end()
   })
@@ -67,15 +69,15 @@ export function testAuth() {
     console.log(`V1 storage validation: ${authPart}`)
     const authorization = `bearer ${authPart}`
     const authenticator = auth.parseAuthHeader(authorization)
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong address must throw')
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], 'potatos are tasty'),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], ['potatos are tasty']),
              errors.ValidationError, 'Wrong challenge text must throw')
-    t.ok(authenticator.isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]),
          'Good signature must pass')
 
     // signer address was from the v1 token
-    t.equal(authenticator.isAuthenticationValid(testAddrs[0], challengeText), testAddrs[0])
+    t.equal(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]), testAddrs[0])
 
     const signerKeyHex = testPairs[0].d.toHex()
     const tokenWithoutIssuer = new TokenSigner('ES256K', signerKeyHex).sign(
@@ -86,13 +88,13 @@ export function testAuth() {
       { gaiaChallenge: challengeText, iss: testPairs[0].getPublicKeyBuffer().toString('hex'), exp: 1 })
     const wrongIssuerToken = new TokenSigner('ES256K', signerKeyHex).sign(
       { gaiaChallenge: challengeText, iss: testPairs[1].getPublicKeyBuffer().toString('hex'), exp: 1 })
-    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'No `iss`, should fail')
-    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'Expired token should fail')
-    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Invalid signature')
-    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], [challengeText]),
          'Valid token without expiration should pass')
 
     t.end()
@@ -104,15 +106,15 @@ export function testAuth() {
     console.log(`V1 storage validation: ${authPart}`)
     const authorization = `bearer ${authPart}`
     const authenticator = auth.parseAuthHeader(authorization)
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong address must throw')
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], 'potatos are tasty'),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], ['potatos are tasty']),
              errors.ValidationError, 'Wrong challenge text must throw')
-    t.ok(authenticator.isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]),
          'Good signature must pass')
 
     // signer address was from the v1 token
-    t.equal(authenticator.isAuthenticationValid(testAddrs[0], challengeText), testAddrs[0])
+    t.equal(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]), testAddrs[0])
 
     const signerKeyHex = testPairs[0].d.toHex()
     const tokenWithoutIssuer = new TokenSigner('ES256K', signerKeyHex).sign(
@@ -123,13 +125,13 @@ export function testAuth() {
       { gaiaChallenge: challengeText, iss: testPairs[0].getPublicKeyBuffer().toString('hex'), exp: 1 })
     const wrongIssuerToken = new TokenSigner('ES256K', signerKeyHex).sign(
       { gaiaChallenge: challengeText, iss: testPairs[1].getPublicKeyBuffer().toString('hex'), exp: 1 })
-    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'No `iss`, should fail')
-    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'Expired token should fail')
-    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Invalid signature')
-    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], [challengeText]),
          'Valid token without expiration should pass')
 
     t.end()
@@ -142,15 +144,15 @@ export function testAuth() {
     console.log(`V1 storage validation: ${authPart}`)
     const authorization = `bearer ${authPart}`
     const authenticator = auth.parseAuthHeader(authorization)
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong address must throw')
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], 'potatos are tasty'),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], ['potatos are tasty']),
              errors.ValidationError, 'Wrong challenge text must throw')
-    t.ok(authenticator.isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]),
          'Good signature must pass')
 
     // signer address was from the association token
-    t.equal(authenticator.isAuthenticationValid(testAddrs[0], challengeText), testAddrs[1])
+    t.equal(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]), testAddrs[1])
 
     // failures should work the same if the outer JWT is invalid
     const signerKeyHex = testPairs[0].d.toHex()
@@ -162,13 +164,13 @@ export function testAuth() {
       { gaiaChallenge: challengeText, iss: testPairs[0].getPublicKeyBuffer().toString('hex'), exp: 1 })
     const wrongIssuerToken = new TokenSigner('ES256K', signerKeyHex).sign(
       { gaiaChallenge: challengeText, iss: testPairs[1].getPublicKeyBuffer().toString('hex'), exp: 1 })
-    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(tokenWithoutIssuer).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'No `iss`, should fail')
-    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], challengeText),
+    t.throws(() => new auth.V1Authentication(expiredToken).isAuthenticationValid(testAddrs[0], [challengeText]),
              errors.ValidationError, 'Expired token should fail')
-    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => new auth.V1Authentication(wrongIssuerToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Invalid signature')
-    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(new auth.V1Authentication(goodTokenWithoutExp).isAuthenticationValid(testAddrs[0], [challengeText]),
          'Valid token without expiration should pass')
 
     // invalid associationTokens should cause a well-formed outer JWT to fail authentication
@@ -189,15 +191,15 @@ export function testAuth() {
       return new auth.V1Authentication(auth.V1Authentication.fromAuthPart(auth.V1Authentication.makeAuthPart(keypair, ct, assocJWT)).token)
     }
 
-    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, associationTokenWithoutIssuer).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, associationTokenWithoutIssuer).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'No `iss` in association token, should fail')
-    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, associationTokenWithoutExp).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, associationTokenWithoutExp).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Association token without exp should fail')
-    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, expiredAssociationToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, expiredAssociationToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Expired association token should fail')
-    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, wrongIssuerAssociationToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, wrongIssuerAssociationToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong association token issuer, should fail')
-    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, wrongBearerAddressAssociationToken).isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => makeAssocAuthToken(testPairs[1], challengeText, wrongBearerAddressAssociationToken).isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong bearer address for association token, should fail')
 
     t.end()
@@ -267,11 +269,11 @@ export function testAuth() {
 
     const authorization = `bearer ${authPart}`
     const authenticator = auth.parseAuthHeader(authorization)
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], challengeText),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[1], [challengeText]),
              errors.ValidationError, 'Wrong address must throw')
-    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], 'potatos are tasty'),
+    t.throws(() => authenticator.isAuthenticationValid(testAddrs[0], ['potatos are tasty']),
              errors.ValidationError, 'Wrong challenge text must throw')
-    t.ok(authenticator.isAuthenticationValid(testAddrs[0], challengeText),
+    t.ok(authenticator.isAuthenticationValid(testAddrs[0], [challengeText]),
          'Good signature must pass')
 
     // scopes must be present

--- a/hub/test/src/testServer.js
+++ b/hub/test/src/testServer.js
@@ -96,8 +96,12 @@ export function testServer() {
                                  { whitelist: [testAddrs[0]], requireCorrectHubUrl: true,
                                    validHubUrls: ['https://testserver.com'] })
 
-    const challengeTexts = auth.getChallengeTexts()
-    t.ok(challengeTexts[1].indexOf('2018') > 0, '2018 challenge text')
+    const challengeTexts = []
+    challengeTexts.push(auth.getChallengeText())
+    auth.getLegacyChallengeTexts().forEach(challengeText => challengeTexts.push(challengeText))
+
+    const challenge2018 = challengeTexts.find(x => x.indexOf('2018') > 0)
+    t.ok(challenge2018, 'Should find a valid 2018 challenge text')
 
     const authPartGood1 = auth.V1Authentication.makeAuthPart(testPairs[0], challengeTexts[1], undefined, 'https://testserver.com/')
     const authPartGood2 = auth.V1Authentication.makeAuthPart(testPairs[0], challengeTexts[1], undefined, 'https://testserver.com')


### PR DESCRIPTION
This deprecates the annual timestamp in the challenge text -- it just replaces it with '0'.

This incorporates legacy years (2018, 2019) in challenge text checks as well.