### PR TITLE
Add support for explicit blacklisting of tokens

### DIFF
--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -359,7 +359,7 @@ export function parseAuthHeader(authHeader: string) {
   }
 }
 
-export function isBlackListedAuthorization(authHeader: string, blacklist: ?Map<string, boolean>) {
+export function isBlackListedAuthorization(authHeader: string, blacklist: ?Set<string>) {
   if (!blacklist)
     return
   if (!authHeader || !authHeader.toLowerCase().startsWith('bearer')) {
@@ -374,7 +374,7 @@ export function isBlackListedAuthorization(authHeader: string, blacklist: ?Map<s
 export function validateAuthorizationHeader(authHeader: string, serverName: string,
                                             address: string, requireCorrectHubUrl?: boolean = false,
                                             validHubUrls?: ?Array<string> = null,
-                                            blacklist?: ?Map<string, boolean> = null): string {
+                                            blacklist?: ?Set<string> = null): string {
   const serverNameHubUrl = `https://${serverName}`
   if (!validHubUrls) {
     validHubUrls = [ serverNameHubUrl ]

--- a/hub/src/server/config.js
+++ b/hub/src/server/config.js
@@ -14,6 +14,7 @@ export const configDefaults = {
     json: false
   },
   whitelist: null,
+  tokenBlacklist: null,
   readURL: null,
   driver: undefined,
   validHubUrls: undefined,
@@ -27,6 +28,7 @@ export const configDefaults = {
 }
 
 const globalEnvVars = { whitelist: 'GAIA_WHITELIST',
+                        tokenBlacklist: 'GAIA_TOKEN_BLACKLIST',
                         readURL: 'GAIA_READ_URL',
                         driver: 'GAIA_DRIVER',
                         validHubUrls: 'GAIA_VALID_HUB_URLS',
@@ -38,7 +40,7 @@ const globalEnvVars = { whitelist: 'GAIA_WHITELIST',
                         port: 'GAIA_PORT' }
 
 const parseInts = [ 'port', 'pageSize', 'requireCorrectHubUrl' ]
-const parseLists = [ 'validHubUrls', 'whitelist' ]
+const parseLists = [ 'validHubUrls', 'whitelist', 'tokenBlacklist' ]
 
 function getConfigEnv(envVars) {
 

--- a/hub/src/server/server.js
+++ b/hub/src/server/server.js
@@ -10,17 +10,23 @@ export class HubServer {
   driver: DriverModel
   proofChecker: Object
   whitelist: Array<string>
+  blacklist: Map<string, boolean>
   serverName: string
   readURL: ?string
   requireCorrectHubUrl: boolean
   validHubUrls: ?Array<string>
   constructor(driver: DriverModel, proofChecker: Object,
               config: { whitelist: Array<string>, serverName: string,
+                        tokenBlacklist: Array<string>,
                         readURL?: string, requireCorrectHubUrl?: boolean,
                         validHubUrls?: Array<string> }) {
     this.driver = driver
     this.proofChecker = proofChecker
     this.whitelist = config.whitelist
+    this.blacklist = new Map()
+    if (config.tokenBlacklist) {
+      config.tokenBlacklist.forEach(x => this.blacklist.set(x, true))
+    }
     this.serverName = config.serverName
     this.validHubUrls = config.validHubUrls
     this.readURL = config.readURL
@@ -33,7 +39,8 @@ export class HubServer {
     const signingAddress = validateAuthorizationHeader(requestHeaders.authorization,
                                                        this.serverName, address,
                                                        this.requireCorrectHubUrl,
-                                                       this.validHubUrls)
+                                                       this.validHubUrls,
+                                                       this.blacklist)
 
     if (this.whitelist && !(this.whitelist.includes(signingAddress))) {
       throw new ValidationError(`Address ${signingAddress} not authorized for writes`)

--- a/hub/src/server/server.js
+++ b/hub/src/server/server.js
@@ -10,7 +10,7 @@ export class HubServer {
   driver: DriverModel
   proofChecker: Object
   whitelist: Array<string>
-  blacklist: Map<string, boolean>
+  blacklist: Set<string>
   serverName: string
   readURL: ?string
   requireCorrectHubUrl: boolean
@@ -23,9 +23,9 @@ export class HubServer {
     this.driver = driver
     this.proofChecker = proofChecker
     this.whitelist = config.whitelist
-    this.blacklist = new Map()
+    this.blacklist = new Set()
     if (config.tokenBlacklist) {
-      config.tokenBlacklist.forEach(x => this.blacklist.set(x, true))
+      config.tokenBlacklist.forEach(x => this.blacklist.add(x))
     }
     this.serverName = config.serverName
     this.validHubUrls = config.validHubUrls

--- a/hub/test/src/testAuth.js
+++ b/hub/test/src/testAuth.js
@@ -35,19 +35,19 @@ export function testAuth() {
         'Y5ZGI3ZTc4MTIwYTVmMjY1YzExZmY0ODc4OTBlNDQ1MWZjYWM3NjA4NTkyMDhjZWMwMjIwNTZkY2I0OGUyYzE' +
         '4Y2YwZjQ1NDZiMmQ3M2I2MDY4MWM5ODEyMzQyMmIzOTRlZjRkMWI2MjE3NTYyODQ4MzUwNCJ9' }
 
-    const blacklist = new Map()
+    const blacklist = new Set()
     t.doesNotThrow(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
                                                           legacyPart.serverName,
                                                           legacyPart.addr),
                    'authentication token should work without blacklist')
-    blacklist.set('asdjsdja', true)
+    blacklist.add('asdjsdja')
 
     t.doesNotThrow(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
                                                           legacyPart.serverName,
                                                           legacyPart.addr, undefined, undefined, blacklist),
                    'authentication token should work without being in the blacklist')
 
-    blacklist.set(legacyPart.legacyAuth, true)
+    blacklist.add(legacyPart.legacyAuth)
 
     t.throws(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
                                                     legacyPart.serverName,

--- a/hub/test/src/testAuth.js
+++ b/hub/test/src/testAuth.js
@@ -25,6 +25,38 @@ export function testAuth() {
     t.end()
   })
 
+  test('blacklist authentication', (t) => {
+    const legacyPart = {
+      wif: 'Kzp44Hhp6SFUXMuMi6MUDTqyfcNyyjntrphEHVMsiitRrjMyoV4p',
+      addr: '1AotVNASQouiNiBtfxv49WWvSNcQUzGYuU',
+      serverName: 'storage.blockstack.org',
+      legacyAuth: 'eyJwdWJsaWNrZXkiOiIwMjQxYTViMDQ2Mjg1ZjVlMjgwMDRmOTJjY2M0MjNmY2RkODYyZmYzY' +
+        'jgwODUwNzE4MDY4MGIyNDA3ZTIyOWE3NzgiLCJzaWduYXR1cmUiOiIzMDQ0MDIyMDY5ODUwNmNjYjg3MDg1Zm' +
+        'Y5ZGI3ZTc4MTIwYTVmMjY1YzExZmY0ODc4OTBlNDQ1MWZjYWM3NjA4NTkyMDhjZWMwMjIwNTZkY2I0OGUyYzE' +
+        '4Y2YwZjQ1NDZiMmQ3M2I2MDY4MWM5ODEyMzQyMmIzOTRlZjRkMWI2MjE3NTYyODQ4MzUwNCJ9' }
+
+    const blacklist = new Map()
+    t.doesNotThrow(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
+                                                          legacyPart.serverName,
+                                                          legacyPart.addr),
+                   'authentication token should work without blacklist')
+    blacklist.set('asdjsdja', true)
+
+    t.doesNotThrow(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
+                                                          legacyPart.serverName,
+                                                          legacyPart.addr, undefined, undefined, blacklist),
+                   'authentication token should work without being in the blacklist')
+
+    blacklist.set(legacyPart.legacyAuth, true)
+
+    t.throws(() => auth.validateAuthorizationHeader(`bearer ${legacyPart.legacyAuth}`,
+                                                    legacyPart.serverName,
+                                                    legacyPart.addr,
+                                                    undefined, undefined, blacklist),
+             'blacklisted authentication token should throw')
+    t.end()
+  })
+
   test('authentication legacy/regression with multi-case bearer', (t) => {
     const legacyPart = {
       wif: 'Kzp44Hhp6SFUXMuMi6MUDTqyfcNyyjntrphEHVMsiitRrjMyoV4p',


### PR DESCRIPTION
This allows us to explicitly blacklist tokens.

You would use this, e.g., if you knew specific tokens were compromised, and you wanted to invalidate some, but not all, tokens.