### PR TITLE
Hotfix for promise rejection behavior

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3]
+### Fixed
+- Errors which previously caused 500s now correctly result in 4xx errors
+  in the event of validation failures.
+
 ## [2.3.0]
 ### Added
 - Support for scoped authentication tokens via a new `scopes` field in

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/authentication.js
+++ b/hub/src/server/authentication.js
@@ -246,7 +246,13 @@ export class V1Authentication {
       validateScopes(scopes)
     }
 
-    const verified = new TokenVerifier('ES256K', publicKey).verify(this.token)
+    let verified
+    try {
+      verified = new TokenVerifier('ES256K', publicKey).verify(this.token)
+    } catch (err) {
+      throw new ValidationError('Failed to verify supplied authentication JWT')
+    }
+
     if (!verified) {
       throw new ValidationError('Failed to verify supplied authentication JWT')
     }

--- a/hub/src/server/server.js
+++ b/hub/src/server/server.js
@@ -43,8 +43,10 @@ export class HubServer {
   handleListFiles(address: string,
                   page: ?string,
                   requestHeaders: { authorization: string }) {
-    this.validate(address, requestHeaders)
-    return this.driver.listFiles(address, page)
+    return Promise.resolve().then(() => {
+      this.validate(address, requestHeaders)
+      return this.driver.listFiles(address, page)
+    })
   }
 
   getReadURLPrefix() {
@@ -60,57 +62,58 @@ export class HubServer {
                                  'content-length': string,
                                  authorization: string},
                 stream: Readable) {
-    this.validate(address, requestHeaders)
+    return Promise.resolve().then(() => {
+      this.validate(address, requestHeaders)
 
-    let contentType = requestHeaders['content-type']
+      let contentType = requestHeaders['content-type']
 
-    if (contentType === null || contentType === undefined) {
-      contentType = 'application/octet-stream'
-    }
-
-
-    // can the caller write? if so, in what paths?
-    const scopes = getAuthenticationScopes(requestHeaders.authorization)
-    const writePrefixes = []
-    const writePaths = []
-    for (let i = 0; i < scopes.length; i++) {
-      if (scopes[i].scope == 'putFilePrefix') {
-        writePrefixes.push(scopes[i].domain)
-      } else if (scopes[i].scope == 'putFile') {
-        writePaths.push(scopes[i].domain)
-      }
-    }
-
-    if (writePrefixes.length > 0 || writePaths.length > 0) {
-      // we're limited to a set of prefixes and paths.
-      // does the given path match any prefixes?
-      let match = !!writePrefixes.find((p) => (path.startsWith(p)))
-
-      if (!match) {
-        // check for exact paths 
-        match = !!writePaths.find((p) => (path === p))
+      if (contentType === null || contentType === undefined) {
+        contentType = 'application/octet-stream'
       }
 
-      if (!match) {
-        // not authorized to write to this path 
-        throw new ValidationError(`Address ${address} not authorized to write to ${path} by scopes`)
-      }
-    }
-
-    const writeCommand = { storageTopLevel: address,
-                           path, stream, contentType,
-                           contentLength: parseInt(requestHeaders['content-length']) }
-
-    return this.proofChecker.checkProofs(address, path, this.getReadURLPrefix())
-      .then(() => this.driver.performWrite(writeCommand))
-      .then((readURL) => {
-        const driverPrefix = this.driver.getReadURLPrefix()
-        const readURLPrefix = this.getReadURLPrefix()
-        if (readURLPrefix !== driverPrefix && readURL.startsWith(driverPrefix)) {
-          const postFix = readURL.slice(driverPrefix.length)
-          return `${readURLPrefix}${postFix}`
+      // can the caller write? if so, in what paths?
+      const scopes = getAuthenticationScopes(requestHeaders.authorization)
+      const writePrefixes = []
+      const writePaths = []
+      for (let i = 0; i < scopes.length; i++) {
+        if (scopes[i].scope == 'putFilePrefix') {
+          writePrefixes.push(scopes[i].domain)
+        } else if (scopes[i].scope == 'putFile') {
+          writePaths.push(scopes[i].domain)
         }
-        return readURL
-      })
+      }
+
+      if (writePrefixes.length > 0 || writePaths.length > 0) {
+        // we're limited to a set of prefixes and paths.
+        // does the given path match any prefixes?
+        let match = !!writePrefixes.find((p) => (path.startsWith(p)))
+
+        if (!match) {
+          // check for exact paths
+          match = !!writePaths.find((p) => (path === p))
+        }
+
+        if (!match) {
+          // not authorized to write to this path
+          throw new ValidationError(`Address ${address} not authorized to write to ${path} by scopes`)
+        }
+      }
+
+      const writeCommand = { storageTopLevel: address,
+                             path, stream, contentType,
+                             contentLength: parseInt(requestHeaders['content-length']) }
+
+      return this.proofChecker.checkProofs(address, path, this.getReadURLPrefix())
+        .then(() => this.driver.performWrite(writeCommand))
+        .then((readURL) => {
+          const driverPrefix = this.driver.getReadURLPrefix()
+          const readURLPrefix = this.getReadURLPrefix()
+          if (readURLPrefix !== driverPrefix && readURL.startsWith(driverPrefix)) {
+            const postFix = readURL.slice(driverPrefix.length)
+            return `${readURLPrefix}${postFix}`
+          }
+          return readURL
+        })
+    })
   }
 }


### PR DESCRIPTION
This wraps the server handler functions in promise.resolve so that exceptions thrown in the handler are caught by the `http` object's `.catch` clauses.

This has the effect of correctly returning errors messages that used to return 500s.

Added a test case to the `testHttp` unit tests to deal with this.