### PR TITLE
PR Review Process and Submission Guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Goal of PR
+
+Please describe exactly what the goal of your PR is (and link to any relevant issues)
+
+## Implementation
+
+Describe how that goal was achieved through the submitted implementation.
+
+## Manual Testing
+
+Describe how the new functionality can be tested manually.
+
+## Automated Testing
+
+Describe the automated testing you included which covers any and all new functionality.
+
+## Submission Checklist
+
+- [ ] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`
+
+- [ ] The code passes our eslint definitions, unit tests, and
+      contains correct TypeFlow annotations.
+
+- [ ] Submission contains tests that cover any and all new functionality or code changes.
+
+- [ ] Submission documents any new features or endpoints, and describes how developers
+      would be expected to interact with them.
+
+- [ ] Author has agreed to our contributor's agreement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Maintainers
+
+The Gaia repo is currently maintained by Aaron Blankstein (@kantai), and reviewers for PRs include
+@jcnelson and @zone117x
+
+# Submitting PRs
+
+A submitted PR must:
+
+1. Describe exactly what the goal of the PR is (and link to any relevant issues)
+2. Describe how that goal was achieved through the submitted implementation.
+3. The code must obey our eslint definitions, pass our unit tests, and
+   contain correct TypeFlow annotations.
+4. Contain tests that cover any and all new functionality or code changes.
+5. Describe how the new functionality can be tested manually.
+6. Document any new features or endpoints, and describe how developers
+   would be expected to interact with them.
+7. PR authors should agree to our contributor's agreement.
+
+PRs on Gaia should be reviewed by at least (2) maintainers.
+
+Most PRs should be based on the `develop` branch, unless it is a hotfix, in which case
+ it should be based on the `master` branch. Maintainers will handle version bumps and updating
+ the `CHANGELOG.md` file.
+
+# Reviewing PRs
+
+A PR reviewer is responsible for ensuring the following:
+
+1. All code changes are covered by automated tests. 
+  a. If a driver is changed, tests _must_ cover any changes in both the mocked driver
+  tests and with real driver tests using credentials for that driver (if necessary).
+  
+2. Does this code change invalidate outstanding authentication tokens? If so,
+   this is a breaking change, and versioning and release notifications must
+   reflect that.
+
+3. Does this code change affect any other kinds of behavior in deployed hubs in a
+   breaking way? If so, this is a breaking change, and versioning and release notifications
+   must reflect that.
+
+4. Does this code change change the typical read/write behavior and expectations of the Gaia
+   hub? Under normal usage, a Gaia hub is responsible only for writes.
+
+5. Does the code match our style guidelines as defined by our eslint definitions? Does type
+   enforcement need to be disabled in any files?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@ A submitted PR must:
 PRs on Gaia should be reviewed by at least (2) maintainers.
 
 Most PRs should be based on the `develop` branch, unless it is a hotfix, in which case
- it should be based on the `master` branch. Maintainers will handle version bumps and updating
- the `CHANGELOG.md` file.
+ it should be based on the `master` branch. We prefer that you do not do any squashing on
+ your commits (we like to see the whole history of edits).  Maintainers will handle version 
+ bumps and updating the `CHANGELOG.md` file.
 
 # Reviewing PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,16 @@ A PR reviewer is responsible for ensuring the following:
    this is a breaking change, and versioning and release notifications must
    reflect that.
 
-3. Does this code change affect any other kinds of behavior in deployed hubs in a
+3. Does this code change the way data is written to any existing drivers? If so,
+   do tests ensure that the written file data and meta-data (like Content-Type, Cache-Control)
+   match exactly what was written previously? If no, why is this breaking change necessary?
+
+4. Does this code change affect any other kinds of behavior in deployed hubs in a
    breaking way? If so, this is a breaking change, and versioning and release notifications
    must reflect that.
 
-4. Does this code change change the typical read/write behavior and expectations of the Gaia
+5. Does this code change change the typical read/write behavior and expectations of the Gaia
    hub? Under normal usage, a Gaia hub is responsible only for writes.
 
-5. Does the code match our style guidelines as defined by our eslint definitions? Does type
+6. Does the code match our style guidelines as defined by our eslint definitions? Does type
    enforcement need to be disabled in any files?

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Blockstack
+Copyright (c) 2019 Blockstack
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is a pretty skeletal CONTRIBUTING doc that roughly describes the PR review process, and what the PR author and PR reviewer are responsible for.

The goal here is to highlight what part of the review process affects QA specifically for Gaia.

The important things to check for QA in Gaia are:

1. Whether or not authentication tokens are affected by a particular PR.
2. Whether or not the PR changes how the deployed hub writes or expects to read data.
3. Whether or not the PR expects to add significant load to the hub server.

And so this was added to the explicit instructions for a reviewer.