### PR TITLE
Config schema enforcement

### DIFF
--- a/hub/config.sample.json
+++ b/hub/config.sample.json
@@ -1,33 +1,15 @@
 {
-  "servername": "",
+  "serverName": "",
   "port": 3000,
-  "driver": "",
+  "driver": "aws",
   "bucket": "",
   "readURL": "",
-  "awsCredentials": {
-    "accessKeyId": "",
-    "secretAccessKey": ""
-  },
-
-  "proofsConfig": {
-    "proofsRequired" : 3
-  },
-
-  "azCredentials": {
-    "accountName": "",
-    "accountKey": ""
-  },
-
-  "gcCredentials": {
-    "projectId": ""
-  },
-
   "argsTransport": {
     "level": "warn",
     "handleExceptions": true,
     "stringify": true,
     "timestamp": true,
     "colorize": false,
-    "json": true
+    "json": false
   }
 }

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -3903,6 +3903,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
       "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    },
     "jsontokens": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.8.tgz",

--- a/hub/package.json
+++ b/hub/package.json
@@ -18,6 +18,7 @@
     "express": "^4.15.4",
     "express-winston": "^2.4.0",
     "fs-extra": "^7.0.1",
+    "jsonschema": "^1.2.4",
     "jsontokens": "^0.7.8",
     "lru-cache": "^5.1.1",
     "node-fetch": "^2.3.0",

--- a/hub/src/server/config-schema.json
+++ b/hub/src/server/config-schema.json
@@ -29,7 +29,7 @@
       {
         "type": "object",
         "properties": {
-          "proofsRequired": { "type": "string"}
+          "proofsRequired": { "type": "integer"}
         },
         "required": [
           "proofsRequired"

--- a/hub/src/server/config-schema.json
+++ b/hub/src/server/config-schema.json
@@ -3,12 +3,12 @@
   "type": "object",
   "properties": {
     "serverName": { "type": "string" },
-    "port": { "type": "integer" },
+    "port": { "type": "integer", "minimum": 0, "maximum": 65535 },
     "driver": { "type": { "enum":
                           [ "aws", "azure", "disk", "google-cloud" ] } },
     "bucket": { "type": "string" },
     "readURL": { "type": "string" },
-    "pageSize": { "type": "integer"},
+    "pageSize": { "type": "integer", "minimum": 1, "maximum": 4096 },
     "requireCorrectHubUrl": { "type": "boolean" },
     "cacheControl": { "type": "string" },
     "whitelist": { "oneOf": [

--- a/hub/src/server/config-schema.json
+++ b/hub/src/server/config-schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "serverName": { "type": "string" },
+    "port": { "type": "integer" },
+    "driver": { "type": { "enum":
+                          [ "aws", "azure", "disk", "google-cloud" ] } },
+    "bucket": { "type": "string" },
+    "readURL": { "type": "string" },
+    "pageSize": { "type": "integer"},
+    "requireCorrectHubUrl": { "type": "boolean" },
+    "cacheControl": { "type": "string" },
+    "whitelist": { "oneOf": [
+      {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      { "type": ["boolean", "null"] }
+    ]},
+    "validHubUrls": { "oneOf": [
+      {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      { "type": ["boolean", "null"] }
+    ]},
+    "proofsConfig": { "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "proofsRequired": { "type": "string"}
+        },
+        "required": [
+          "proofsRequired"
+        ]
+      },
+      { "type": ["boolean", "null"] }
+    ]},
+    "awsCredentials": {
+      "type": "object",
+      "properties": {
+        "sessionToken": { "type": "string"},
+        "accessKeyId": { "type": "string"},
+        "secretAccessKey": { "type": "string"}
+      }
+    },
+    "azCredentials": {
+      "type": "object",
+      "properties": {
+        "accountName": { "type": "string"},
+        "accountKey": { "type": "string"}
+      }
+    },
+    "gcCredentials": {
+      "type": "object",
+      "properties": {
+        "email": { "type": "string"},
+        "projectId": { "type": "string"},
+        "keyFilename": { "type": "string"},
+        "credentials": { "type": "object",
+                         "properties": {
+                           "client_email": "string",
+                           "private_key": "string"
+                         }}
+      }
+    },
+    "diskSettings": {
+      "type": "object",
+      "properties": {
+        "storageRootDirectory": { "type": "string"}
+      }
+    },
+    "argsTransport": {
+      "type": "object",
+      "properties": {
+        "level": { "type": "string"},
+        "handleExceptions": { "type": "boolean" },
+        "stringify": { "type": "boolean" },
+        "timestamp": { "type": "boolean" },
+        "colorize": { "type": "boolean" },
+        "json":{ "type": "boolean" }
+      }
+    },
+    "servername": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/hub/test/data/config.aws.json
+++ b/hub/test/data/config.aws.json
@@ -1,0 +1,10 @@
+{
+  "servername": "storage.blockstack.org",
+  "port": 5000,
+  "driver": "aws",
+  "bucket": "ablankst-blockstack",
+  "argsTransport" : {
+    "level": "info",
+    "json": false
+  }
+}

--- a/hub/test/data/config.azure.json
+++ b/hub/test/data/config.azure.json
@@ -1,0 +1,15 @@
+{
+  "servername": "storage.blockstack.org",
+  "port": 5000,
+  "driver": "azure",
+  "bucket": "hub",
+  "argsTransport" : {
+    "level": "debug",
+    "json": false
+  },
+
+  "azCredentials": {
+    "accountName": "aaronblockstackstorage",
+    "accountKey": "1jskadjskajsd1191sjkla"
+  }
+}

--- a/hub/test/data/config.bad.json
+++ b/hub/test/data/config.bad.json
@@ -1,0 +1,4 @@
+{
+  "driver": "azure",
+  "port": "potatos"
+}

--- a/hub/test/data/config.disk.json
+++ b/hub/test/data/config.disk.json
@@ -1,0 +1,15 @@
+{
+  "servername": "storage.blockstack.org",
+  "port": 5000,
+  "readURL": "http://localhost/sample/",
+  "driver": "disk",
+  "diskSettings": {
+    "storageRootDirectory": "/tmp/foo/"
+  },
+  "bucket": "hub",
+  "argsTransport" : {
+    "level": "debug",
+    "json": false,
+    "timestamp": true
+  }
+}

--- a/hub/test/data/config.sample.json
+++ b/hub/test/data/config.sample.json
@@ -4,6 +4,7 @@
   "driver": "aws",
   "bucket": "",
   "readURL": "",
+  "whitelist": [ "15GAGiT2j2F1EzZrvjk3B8vBCfwVEzQaZx" ],
   "argsTransport": {
     "level": "warn",
     "handleExceptions": true,

--- a/hub/test/data/config.sample.json
+++ b/hub/test/data/config.sample.json
@@ -1,0 +1,15 @@
+{
+  "serverName": "",
+  "port": 3000,
+  "driver": "aws",
+  "bucket": "",
+  "readURL": "",
+  "argsTransport": {
+    "level": "warn",
+    "handleExceptions": true,
+    "stringify": true,
+    "timestamp": true,
+    "colorize": false,
+    "json": false
+  }
+}

--- a/hub/test/data/test.gc.json
+++ b/hub/test/data/test.gc.json
@@ -1,0 +1,4 @@
+{
+  "gcCredentials": {},
+  "bucket": "spokes"
+}

--- a/hub/test/src/testConfig.js
+++ b/hub/test/src/testConfig.js
@@ -40,7 +40,7 @@ export function testConfig() {
                                          { azCredentials: { accountName: undefined,
                                                             accountKey: undefined }})
 
-    t.deepEqual(configResult, configExpected)
+    t.deepEqual(configResult, configExpected, "Should have been equal")
     process.env.CONFIG_PATH = configOriginal
     t.end()
   })
@@ -54,6 +54,34 @@ export function testConfig() {
                                          { azCredentials: { accountName: 'pancakes', accountKey: undefined }})
 
     t.deepEqual(configResult, configExpected)
+    process.env.CONFIG_PATH = configOriginal
+    t.end()
+  })
+
+  test('sample configs pass validation', (t) => {
+    const configOriginal = process.env.CONFIG_PATH
+    const configs = ['config.aws.json',
+                     'config.disk.json',
+                     'config.sample.json',
+                     'test.azure.json',
+                     'test.gc.json']
+    for (let conf of configs) {
+      process.env.CONFIG_PATH = `${configDir}/${conf}`
+
+      t.ok(config.getConfig())
+    }
+    process.env.CONFIG_PATH = configOriginal
+    t.end()
+  })
+
+  test('bad config fails validation', (t) => {
+    const configOriginal = process.env.CONFIG_PATH
+    const configs = [ 'config.bad.json' ]
+    for (let conf of configs) {
+      process.env.CONFIG_PATH = `${configDir}/${conf}`
+
+      t.throws(() => config.getConfig())
+    }
     process.env.CONFIG_PATH = configOriginal
     t.end()
   })


### PR DESCRIPTION
This add (pretty light) JSON schema enforcement to the hub's config JSON.

Any currently working configuration should continue to work -- though if the config file contained invalid or unused properties, that file would no longer work.

We don't use `required` parameters for the most part in this file, because any of these settings could instead be set via environment variables.

I added test cases to cover sample configs and test enforcment of a bad JSON file.