### PR TITLE
[S3 driver] Endpoint config for using services other than AWS

### DIFF
--- a/hub/src/server/drivers/S3Driver.ts
+++ b/hub/src/server/drivers/S3Driver.ts
@@ -9,7 +9,8 @@ type S3_CONFIG_TYPE = {
   awsCredentials: {
     accessKeyId?: string,
     secretAccessKey?: string,
-    sessionToken?: string
+    sessionToken?: string,
+    endpoint?: string
   },
   pageSize?: number,
   cacheControl?: string,
@@ -18,6 +19,7 @@ type S3_CONFIG_TYPE = {
 
 class S3Driver implements DriverModel, DriverModelTestMethods {
   s3: S3
+  endpoint: string
   bucket: string
   pageSize: number
   cacheControl?: string
@@ -46,6 +48,11 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
   }
 
   constructor (config: S3_CONFIG_TYPE) {
+    if (config.awsCredentials && config.awsCredentials.endpoint) {
+      this.endpoint = config.awsCredentials.endpoint
+    } else {
+      this.endpoint = 's3.amazonaws.com'
+    }
     this.s3 = new S3(config.awsCredentials)
     this.bucket = config.bucket
     this.pageSize = config.pageSize ? config.pageSize : 100
@@ -67,7 +74,7 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
   }
 
   getReadURLPrefix(): string {
-    return `https://${this.bucket}.s3.amazonaws.com/`
+    return `https://${this.bucket}.${this.endpoint}/`
   }
 
   async createIfNeeded () {
@@ -120,19 +127,27 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
 
   async listAllKeys(prefix: string, page?: string): Promise<ListFilesResult> {
     // returns {'entries': [...], 'page': next_page}
-    const opts: { Bucket: string, MaxKeys: number, Prefix: string, ContinuationToken?: string } = {
+    const opts: S3.ListObjectsRequest = {
       Bucket: this.bucket,
       MaxKeys: this.pageSize,
       Prefix: prefix
     }
     if (page) {
-      opts.ContinuationToken = page
+      opts.Marker = page
     }
-
-    const data = await this.s3.listObjectsV2(opts).promise()
+    const data = await this.s3.listObjects(opts).promise()
     const res: ListFilesResult = {
       entries: data.Contents.map((e) => e.Key.slice(prefix.length + 1)),
-      page: data.IsTruncated ? data.NextContinuationToken : null
+      page: data.IsTruncated ? data.NextMarker : null
+    }
+    /**
+     * "If the response does not include the NextMarker and it is truncated, you 
+     *  can use the value of the last Key in the response as the marker in the 
+     *  subsequent request to get the next set of object keys."
+     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html
+     */
+    if (data.IsTruncated && !res.page && data.Contents.length > 0) {
+      res.page = data.Contents[data.Contents.length - 1].Key
     }
     return res
   }

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -216,8 +216,11 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
         t.equal(remainingFiles.entries.length, 2, 'List files with pagination should have returned 2 remaining entries')
 
         try {
-          await driver.listFiles(`${topLevelStorage}/${pageTestDir}`, "bogus page data")
-          t.fail('List files with invalid page data should have failed')
+          const bogusPageResult = await driver.listFiles(`${topLevelStorage}/${pageTestDir}`, "bogus page data")
+          if (bogusPageResult.entries.length > 0) {
+            t.fail('List files with invalid page data should fail or return no results')
+          }
+          t.pass('List files with invalid page data should fail or return no results')
         } catch (error) {
           t.pass('List files with invalid page data should have failed')
         }

--- a/hub/test/src/testDrivers/mockTestDrivers.ts
+++ b/hub/test/src/testDrivers/mockTestDrivers.ts
@@ -153,7 +153,20 @@ export function makeMockedS3Driver() {
           return { Contents: contents, IsTruncated: false }
         }
       }
-
+    }
+    listObjects(options) {
+      return {
+        promise: async () => {
+          const contents = dataMap
+            .filter((entry) => {
+              return (entry.key.slice(0, options.Prefix.length) === options.Prefix)
+            })
+            .map((entry) => {
+              return { Key: entry.key }
+            })
+          return { Contents: contents, IsTruncated: false }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Goal of PR

Provide better support for using cloud storage services that use S3 compatible APIs. 

## Implementation

Two notable changes:
* Allow the S3 driver `getReadURLPrefix()` endpoint to be configurable rather than hardcoded to `s3.amazonaws.com`, no longer requiring overriding through hub-level `readURL` config. 
* Use [`listObjects`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjects-property) instead of [`listObjectsV2`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjectsV2-property) which has more consistent behavior for pagination across tested services (so far AWS, DigitalOcean Spaces, and Wasabi Hot Cloud Storage). 

## Manual Testing

Tested using all the cloud driver integration tests against [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [Wasabi Hot Cloud Storage](https://wasabi.com/hot-cloud-storage/), and of course AWS. 

Did *not* test with a some popular providers with S3 APIs due to setup complexity/cost/hassle, such as [Scality](https://www.scality.com/topics/s3-compatible-storage/), [MinIO](https://min.io/), [Backblaze](https://www.backblaze.com/blog/how-to-use-minio-with-b2-cloud-storage/). 

## Automated Testing

Unchanged. AWS integration tests still cover the S3 driver. We can add Blockstack PBC owned account creds for the other providers to CircleCI as needed. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
