### PR TITLE
Add `no-cache` header to revocation fetch

### DIFF
--- a/hub/etc/config.sample.s3.json
+++ b/hub/etc/config.sample.s3.json
@@ -9,7 +9,7 @@
   "pageSize": 20,
   "bucket": "YOUR_BUCKET_NAME",
   "awsCredentials": {
-     "accessKeyID": "YOUR_ACCESS_KEY",
+     "accessKeyId": "YOUR_ACCESS_KEY",
      "secretAccessKey": "YOUR_SECRET_KEY"
   },
   "argsTransport": {


### PR DESCRIPTION
## Goal of PR

* Add `cache-control: no-cache` header to revocation fetch.
* Avoid reading revocation fetch contents if status code is bad (waste of hub resources pulling down any fancy CDN's error page content). 

## Testing

No additional tests. I can implement tests later this week.

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [ ] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
