### PR TITLE
Prod-ready package.json "start" commands

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -8,7 +8,8 @@
     "npm": ">=6"
   },
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "npm run build && node lib/index.js",
+    "start-dev": "ts-node src/index.ts",
     "build": "npm run lint && tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/test.ts"

--- a/hub/package.json
+++ b/hub/package.json
@@ -54,7 +54,8 @@
     "blockstack-gaia-hub": "./lib/index.js"
   },
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "npm run build && node lib/index.js",
+    "start-dev": "ts-node src/index.ts",
     "build": "npm run lint && tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"

--- a/reader/package.json
+++ b/reader/package.json
@@ -39,7 +39,8 @@
     "blockstack-gaia-reader": "./lib/index.js"
   },
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "npm run build && node lib/index.js",
+    "start-dev": "ts-node src/index.ts",
     "build": "npm run lint && tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/test.ts"


### PR DESCRIPTION
## Goal of PR

Update package.json `start` commands for more appropriate prod-usage in dockerfiles. 

## Implementation

Use `build && node index.js` rather than `ts-node index.ts` in `npm run start`. Since ts-node is not recommended for prod usage. 

## Manual Testing

Ran `npm run start` on all three sub-projects. 

(TODO: run docker)

## Automated Testing

n/a

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
