### PR TITLE
Config schema generation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 */lib/**/*.js
-*/test/**/*.js
+*/test/**/*.ts

--- a/hub/config-schema.json
+++ b/hub/config-schema.json
@@ -1,0 +1,159 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "argsTransport": {
+            "properties": {
+                "colorize": {
+                    "default": true,
+                    "type": "boolean"
+                },
+                "handleExceptions": {
+                    "default": true,
+                    "type": "boolean"
+                },
+                "json": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "level": {
+                    "default": "warn",
+                    "enum": [
+                        "debug",
+                        "error",
+                        "info",
+                        "verbose",
+                        "warn"
+                    ],
+                    "type": "string"
+                },
+                "timestamp": {
+                    "default": true,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "authTimestampCacheSize": {
+            "default": 50000,
+            "type": "integer"
+        },
+        "awsCredentials": {
+            "description": "Required if `driver` is `aws`",
+            "properties": {
+                "accessKeyId": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "secretAccessKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "azCredentials": {
+            "description": "Required if `driver` is `azure`",
+            "properties": {
+                "accountKey": {
+                    "type": "string"
+                },
+                "accountName": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "bucket": {
+            "default": "hub",
+            "type": "string"
+        },
+        "cacheControl": {
+            "default": "public, max-age=1",
+            "type": "string"
+        },
+        "diskSettings": {
+            "description": "Required if `driver` is `disk`",
+            "properties": {
+                "storageRootDirectory": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "driver": {
+            "enum": [
+                "aws",
+                "azure",
+                "disk",
+                "google-cloud"
+            ],
+            "type": "string"
+        },
+        "gcCredentials": {
+            "description": "Required if `driver` is `google-cloud`",
+            "properties": {
+                "credentials": {
+                    "properties": {
+                        "client_email": {
+                            "type": "string"
+                        },
+                        "private_key": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "projectId": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "pageSize": {
+            "default": 100,
+            "maximum": 4096,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "port": {
+            "default": 3000,
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "proofsConfig": {
+            "properties": {
+                "proofsRequired": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "readURL": {
+            "type": "string"
+        },
+        "requireCorrectHubUrl": {
+            "default": false,
+            "type": "boolean"
+        },
+        "serverName": {
+            "default": "gaia-0",
+            "type": "string"
+        },
+        "validHubUrls": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "whitelist": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}
+

--- a/hub/config-schema.json
+++ b/hub/config-schema.json
@@ -48,6 +48,9 @@
                 },
                 "secretAccessKey": {
                     "type": "string"
+                },
+                "sessionToken": {
+                    "type": "string"
                 }
             },
             "type": "object"
@@ -104,6 +107,12 @@
                     },
                     "type": "object"
                 },
+                "email": {
+                    "type": "string"
+                },
+                "keyFilename": {
+                    "type": "string"
+                },
                 "projectId": {
                     "type": "string"
                 }
@@ -125,7 +134,8 @@
         "proofsConfig": {
             "properties": {
                 "proofsRequired": {
-                    "type": "number"
+                    "default": 0,
+                    "type": "integer"
                 }
             },
             "type": "object"
@@ -154,6 +164,10 @@
             "type": "array"
         }
     },
+    "required": [
+        "driver",
+        "port"
+    ],
     "type": "object"
 }
 

--- a/hub/package-lock.json
+++ b/hub/package-lock.json
@@ -995,6 +995,12 @@
       "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1063,10 +1069,27 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color": {
       "version": "3.0.0",
@@ -1322,6 +1345,12 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -1757,6 +1786,21 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "express": {
       "version": "4.16.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
@@ -1973,6 +2017,15 @@
         }
       }
     },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -2096,6 +2149,33 @@
         "pumpify": "^1.5.1",
         "request": "^2.87.0",
         "stream-events": "^1.0.4"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "getpass": {
@@ -2426,6 +2506,12 @@
           }
         }
       }
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -2787,6 +2873,15 @@
         "colornames": "^1.1.1"
       }
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2795,6 +2890,16 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -2915,6 +3020,15 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -2929,6 +3043,25 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
+      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -3069,6 +3202,15 @@
         "abbrev": "1"
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -3076,6 +3218,12 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "13.3.0",
@@ -4195,10 +4343,63 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "parent-module": {
@@ -4214,6 +4415,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4469,6 +4676,18 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
     "requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -4652,6 +4871,12 @@
         "send": "0.16.2"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
@@ -4819,6 +5044,12 @@
       "requires": {
         "ansi-regex": "^3.0.0"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -5141,6 +5372,18 @@
       "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
+    "typescript-json-schema": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.37.0.tgz",
+      "integrity": "sha512-ipR41ZPQY74X7nOYsoiI6dgCrU+etui9yvsZH3qeTp2938G4nsdce5bxQhdlWE7OPoP+adKkvukIptvuPhv4PQ==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.2",
+        "json-stable-stringify": "^1.0.1",
+        "typescript": "^3.0.1",
+        "yargs": "^12.0.1"
+      }
+    },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -5271,6 +5514,12 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
     "wif": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
@@ -5322,6 +5571,53 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5370,10 +5666,46 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
     "yallist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+    },
+    "yargs": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yn": {
       "version": "3.0.0",

--- a/hub/package.json
+++ b/hub/package.json
@@ -10,7 +10,6 @@
     "@azure/storage-blob": "^10.3.0",
     "@google-cloud/storage": "^2.4.2",
     "aws-sdk": "^2.413.0",
-    "bigi": "^1.4.2",
     "bitcoinjs-lib": "^4.0.3",
     "blockstack": "^18.3.0",
     "body-parser": "^1.18.3",
@@ -56,7 +55,7 @@
   },
   "scripts": {
     "start": "npm run build && node lib/index.js",
-    "start-dev": "ts-node src/index.ts",
+    "dev": "ts-node src/index.ts",
     "build": "npm run lint && tsc && chmod +x lib/index.js && npm run build-schema",
     "build-schema": "typescript-json-schema tsconfig.json HubConfig --required --refs=false -o config-schema.json",
     "lint": "eslint --ext .ts ./src",

--- a/hub/package.json
+++ b/hub/package.json
@@ -48,16 +48,18 @@
     "tape": "^4.10.1",
     "tape-promise": "^4.0.0",
     "ts-node": "^8.0.2",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.3.3333",
+    "typescript-json-schema": "^0.37.0"
   },
   "bin": {
     "blockstack-gaia-hub": "./lib/index.js"
   },
   "scripts": {
     "start": "ts-node src/index.ts",
-    "build": "npm run lint && tsc && chmod +x lib/index.js",
+    "build": "npm run lint && tsc && chmod +x lib/index.js && npm run build-schema",
+    "build-schema": "typescript-json-schema tsconfig.json HubConfig -o config-schema.json",
     "lint": "eslint --ext .ts ./src",
-    "test": "npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"
+    "test": "npm run build && npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"
   },
   "repository": {
     "type": "git",

--- a/hub/package.json
+++ b/hub/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "start": "ts-node src/index.ts",
     "build": "npm run lint && tsc && chmod +x lib/index.js && npm run build-schema",
-    "build-schema": "typescript-json-schema tsconfig.json HubConfig -o config-schema.json",
+    "build-schema": "typescript-json-schema tsconfig.json HubConfig --required --refs=false -o config-schema.json",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run build && npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"
   },

--- a/hub/src/server/ProofChecker.ts
+++ b/hub/src/server/ProofChecker.ts
@@ -4,8 +4,7 @@ import { logger } from './utils'
 import fetch from 'node-fetch'
 
 import { NotEnoughProofError } from './errors'
-
-export type ProofCheckerConfig = { proofsRequired: number }
+import { ProofCheckerConfig } from './config'
 
 export class ProofChecker {
   proofsRequired: number

--- a/hub/src/server/ProofChecker.ts
+++ b/hub/src/server/ProofChecker.ts
@@ -4,12 +4,12 @@ import { logger } from './utils'
 import fetch from 'node-fetch'
 
 import { NotEnoughProofError } from './errors'
-import { ProofCheckerConfig } from './config'
+import { ProofCheckerConfigInterface } from './config'
 
 export class ProofChecker {
   proofsRequired: number
 
-  constructor(proofsConfig?: ProofCheckerConfig) {
+  constructor(proofsConfig?: ProofCheckerConfigInterface) {
     if (!proofsConfig) {
       this.proofsRequired = 0
     } else {

--- a/hub/src/server/config.ts
+++ b/hub/src/server/config.ts
@@ -14,7 +14,7 @@ export type DriverName = 'aws' | 'azure' | 'disk' | 'google-cloud'
 
 export type LogLevel = 'error' | 'warn' | 'info' | 'verbose' | 'debug'
 
-export interface LoggingConfig {
+export interface LoggingConfigInterface {
   timestamp?: boolean;
   colorize?: boolean;
   json?: boolean;
@@ -22,16 +22,33 @@ export interface LoggingConfig {
   handleExceptions?: boolean;
 }
 
-export interface ProofCheckerConfig { 
+// LoggingConfig defaults
+class LoggingConfig implements LoggingConfigInterface {
+  /**
+   * @default warn
+   */
+  level? = 'warn' as LogLevel;
+  handleExceptions? = true;
+  timestamp? = true;
+  colorize? = true;
+  json? = false;
+}
+
+export interface ProofCheckerConfigInterface { 
+  proofsRequired?: number;
+}
+
+// ProofCheckerConfig defaults
+class ProofCheckerConfig implements ProofCheckerConfigInterface {
   /**
    * @TJS-type integer
    */
-  proofsRequired?: number;
+  proofsRequired? = 0;
 }
 
 export interface HubConfigInterface {
   whitelist?: string[];
-  serverName: string;
+  serverName?: string;
   authTimestampCacheSize?: number;
   readURL?: string;
   requireCorrectHubUrl?: boolean;
@@ -41,7 +58,7 @@ export interface HubConfigInterface {
   pageSize?: number;
   cacheControl?: string;
   argsTransport?: LoggingConfig;
-  proofsConfig?: ProofCheckerConfig;
+  proofsConfig?: ProofCheckerConfigInterface;
   driver?: DriverName;
 
   /**
@@ -59,32 +76,49 @@ export interface HubConfigInterface {
   driverClass?: DriverConstructor;
 }
 
-// Class responsible for specifying default config values,
-// as well as used for generating the config-schema.json file. 
-class HubConfig implements HubConfigInterface, AZ_CONFIG_TYPE, DISK_CONFIG_TYPE, GC_CONFIG_TYPE, S3_CONFIG_TYPE {
-  argsTransport = {
-    /**
-     * @default warn
-     */
-    level: 'warn' as LogLevel,
-    handleExceptions: true,
-    timestamp: true,
-    colorize: true,
-    json: false
-  };
-  proofsConfig = {
-    proofsRequired: undefined as number
-  };
-  requireCorrectHubUrl = false;
-  serverName = 'gaia-0';
-  bucket = 'hub';
+type SubType<T, K extends keyof T> = K extends keyof T ? T[K] : never;
+
+// This class is responsible for:
+//  A) Specifying default config values.
+//  B) Used for generating the config-schema.json file. 
+// The undefined values are explicitly specified so the schema generator
+// will pick them up. 
+// Having the config params and their default values specified here is useful 
+// for providing a single-source-of-truth for both the schema and the actual code. 
+class HubConfig implements HubConfigInterface {
+
+  /**
+   * Required if `driver` is `azure`
+   */
+  azCredentials?: SubType<AZ_CONFIG_TYPE, 'azCredentials'>;
+
+  /**
+   * Required if `driver` is `disk`
+   */
+  diskSettings?: SubType<DISK_CONFIG_TYPE, 'diskSettings'>;
+
+  /**
+   * Required if `driver` is `google-cloud`
+   */
+  gcCredentials?: SubType<GC_CONFIG_TYPE, 'gcCredentials'>;
+
+  /**
+   * Required if `driver` is `aws`
+   */
+  awsCredentials?: SubType<S3_CONFIG_TYPE, 'awsCredentials'>;
+
+  argsTransport? = new LoggingConfig();
+  proofsConfig? = new ProofCheckerConfig();
+  requireCorrectHubUrl? = false;
+  serverName? = 'gaia-0';
+  bucket? = 'hub';
   /**
    * @minimum 1
    * @maximum 4096
    * @TJS-type integer
    */
-  pageSize = 100;
-  cacheControl = 'public, max-age=1';
+  pageSize? = 100;
+  cacheControl? = 'public, max-age=1';
   /**
    * @minimum 0
    * @maximum 65535
@@ -94,54 +128,17 @@ class HubConfig implements HubConfigInterface, AZ_CONFIG_TYPE, DISK_CONFIG_TYPE,
   /**
    * @TJS-type integer
    */
-  authTimestampCacheSize = 50000;
+  authTimestampCacheSize? = 50000;
 
   driver = undefined as DriverName;
 
-  // --- Optional values with unused defaults
-  whitelist = undefined as string[]
-  readURL = undefined as string;
-  validHubUrls = undefined as string[];
+  // --- Optional values that default to undefined & unused
+  whitelist?: string[]
+  readURL?: string;
+  validHubUrls?: string[];
   // ---
 
-  /**
-   * Required if `driver` is `azure`
-   */
-  azCredentials = {
-    accountName: undefined as string,
-    accountKey: undefined as string
-  };
-
-  /**
-   * Required if `driver` is `disk`
-   */
-  diskSettings = {
-    storageRootDirectory: undefined as string 
-  };
-
-  /**
-   * Required if `driver` is `google-cloud`
-   */
-  gcCredentials = {
-    projectId: undefined as string,
-    credentials: {
-      private_key: undefined as string,
-      client_email: undefined as string
-    }
-  };
-
-  /**
-   * Required if `driver` is `aws`
-   */
-  awsCredentials = {
-    endpoint: undefined as string,
-    accessKeyId: undefined as string,
-    secretAccessKey: undefined as string
-  };
 }
-
-
-export const configDefaults: HubConfigInterface = new HubConfig()
 
 
 const globalEnvVars = { whitelist: 'GAIA_WHITELIST',
@@ -205,6 +202,27 @@ function deepMerge<T>(target: T, ...sources: T[]): T {
   return deepMerge(target, ...sources)
 }
 
+export function getConfigDefaults(): HubConfigInterface {
+  const configDefaults = new HubConfig()
+
+  // Remove explicit `undefined` values and empty objects
+  function removeEmptyOrUndefined(obj: any) {
+    Object.entries(obj).forEach(([key, val]) => {
+      if (typeof val === 'undefined') {
+        delete obj[key]
+      } else if (typeof val === 'object' && val !== null) {
+        removeEmptyOrUndefined(val)
+        if (Object.keys(val).length === 0) {
+          delete obj[key]
+        }
+      }
+    })
+  }
+  removeEmptyOrUndefined(configDefaults)
+
+  return configDefaults
+} 
+
 export function getConfig() {
   const configPath = process.env.CONFIG_PATH || process.argv[2] || './config.json'
   let configJSON
@@ -223,6 +241,7 @@ export function getConfig() {
 
   const configENV = getConfigEnv(globalEnvVars) as any
 
+  const configDefaults = getConfigDefaults()
   const configGlobal = deepMerge<HubConfigInterface>({} as any, configDefaults, configJSON, configENV)
 
   let config = configGlobal

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -8,8 +8,8 @@ import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverMod
 
 export interface AZ_CONFIG_TYPE {
   azCredentials: {
-    accountName: string,
-    accountKey: string
+    accountName?: string,
+    accountKey?: string
   },
   bucket: string,
   pageSize?: number,

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -6,7 +6,7 @@ import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
 import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs } from '../driverModel'
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
 
-export type AZ_CONFIG_TYPE = {
+export interface AZ_CONFIG_TYPE {
   azCredentials: {
     accountName: string,
     accountKey: string

--- a/hub/src/server/drivers/GcDriver.ts
+++ b/hub/src/server/drivers/GcDriver.ts
@@ -5,7 +5,7 @@ import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs } from '../driverM
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
 import { pipeline, logger } from '../utils'
 
-type GC_CONFIG_TYPE = {
+export interface GC_CONFIG_TYPE {
   gcCredentials?: {
     email?: string,
     projectId?: string,

--- a/hub/src/server/drivers/S3Driver.ts
+++ b/hub/src/server/drivers/S3Driver.ts
@@ -5,7 +5,7 @@ import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs } from '../driverM
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
 import { timeout, logger } from '../utils'
 
-type S3_CONFIG_TYPE = {
+export interface S3_CONFIG_TYPE {
   awsCredentials: {
     accessKeyId?: string,
     secretAccessKey?: string,

--- a/hub/src/server/drivers/diskDriver.ts
+++ b/hub/src/server/drivers/diskDriver.ts
@@ -6,7 +6,7 @@ import { DriverStatics, DriverModel } from '../driverModel'
 import { pipeline, logger } from '../utils'
 
 export interface DISK_CONFIG_TYPE { 
-  diskSettings: { storageRootDirectory: string },
+  diskSettings: { storageRootDirectory?: string },
   bucket?: string,
   pageSize?: number,
   readURL: string 

--- a/hub/src/server/drivers/diskDriver.ts
+++ b/hub/src/server/drivers/diskDriver.ts
@@ -5,10 +5,12 @@ import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs } from '../driverM
 import { DriverStatics, DriverModel } from '../driverModel'
 import { pipeline, logger } from '../utils'
 
-type DISK_CONFIG_TYPE = { diskSettings: { storageRootDirectory: string },
-                          bucket?: string,
-                          pageSize?: number,
-                          readURL: string }
+export interface DISK_CONFIG_TYPE { 
+  diskSettings: { storageRootDirectory: string },
+  bucket?: string,
+  pageSize?: number,
+  readURL: string 
+}
 
 const METADATA_DIRNAME = '.gaia-metadata'
 

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -8,7 +8,7 @@ import { HubServer } from './server'
 import { getDriverClass, logger } from './utils'
 import { DriverModel } from './driverModel'
 import * as errors from './errors'
-import { HubConfig } from './config'
+import { HubConfigInterface } from './config'
 
 function writeResponse(res: express.Response, data: any, statusCode: number) {
   res.writeHead(statusCode, {'Content-Type' : 'application/json'})
@@ -16,7 +16,7 @@ function writeResponse(res: express.Response, data: any, statusCode: number) {
   res.end()
 }
 
-export function makeHttpServer(config: HubConfig): { app: express.Application, server: HubServer, driver: DriverModel } {
+export function makeHttpServer(config: HubConfigInterface): { app: express.Application, server: HubServer, driver: DriverModel } {
 
   const app: express.Application = express()
 

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -3,14 +3,12 @@ import expressWinston from 'express-winston'
 import cors from 'cors'
 
 import { ProofChecker } from './ProofChecker'
-import { ProofCheckerConfig } from './ProofChecker'
 import { getChallengeText, LATEST_AUTH_VERSION } from './authentication'
 import { HubServer } from './server'
-import { HubServerConfig } from './server'
 import { getDriverClass, logger } from './utils'
-import { DriverModel, DriverConstructor } from './driverModel'
+import { DriverModel } from './driverModel'
 import * as errors from './errors'
-import { DriverName } from './config'
+import { HubConfig } from './config'
 
 function writeResponse(res: express.Response, data: any, statusCode: number) {
   res.writeHead(statusCode, {'Content-Type' : 'application/json'})
@@ -18,12 +16,7 @@ function writeResponse(res: express.Response, data: any, statusCode: number) {
   res.end()
 }
 
-export interface MakeHttpServerConfig { 
-  proofsConfig?: ProofCheckerConfig,
-  driverInstance?: DriverModel, driverClass?: DriverConstructor, driver?: DriverName
-}
-
-export function makeHttpServer(config: MakeHttpServerConfig & HubServerConfig & {[k: string]: any}): { app: express.Application, server: HubServer, driver: DriverModel } {
+export function makeHttpServer(config: HubConfig): { app: express.Application, server: HubServer, driver: DriverModel } {
 
   const app: express.Application = express()
 

--- a/hub/src/server/server.ts
+++ b/hub/src/server/server.ts
@@ -7,15 +7,7 @@ import { AuthTimestampCache } from './revocations'
 
 import { Readable } from 'stream'
 import { DriverModel } from './driverModel'
-
-export type HubServerConfig = {
-  whitelist?: Array<string>, 
-  serverName: string, 
-  authTimestampCacheSize: number,
-  readURL?: string, 
-  requireCorrectHubUrl?: boolean, 
-  validHubUrls?: Array<string> 
-}
+import { HubServerConfig } from './config'
 
 export class HubServer {
   driver: DriverModel

--- a/hub/src/server/server.ts
+++ b/hub/src/server/server.ts
@@ -7,7 +7,7 @@ import { AuthTimestampCache } from './revocations'
 
 import { Readable } from 'stream'
 import { DriverModel } from './driverModel'
-import { HubServerConfig } from './config'
+import { HubConfigInterface } from './config'
 
 export class HubServer {
   driver: DriverModel
@@ -19,7 +19,7 @@ export class HubServer {
   validHubUrls?: Array<string>
   authTimestampCache: AuthTimestampCache
 
-  constructor(driver: DriverModel, proofChecker: ProofChecker, config: HubServerConfig) {
+  constructor(driver: DriverModel, proofChecker: ProofChecker, config: HubConfigInterface) {
     this.driver = driver
     this.proofChecker = proofChecker
     this.whitelist = config.whitelist

--- a/hub/test/src/testConfig.ts
+++ b/hub/test/src/testConfig.ts
@@ -9,7 +9,7 @@ export function testConfig() {
 
   test('initial defaults', (t) => {
     const configResult = config.getConfig()
-    t.deepEqual(configResult, config.configDefaults)
+    t.deepEqual(configResult, config.getConfigDefaults())
     t.end()
   })
 
@@ -17,14 +17,14 @@ export function testConfig() {
   test('read envvar with parseInt or parseList', (t) => {
     process.env.GAIA_PAGE_SIZE = '1003'
     let configResult = config.getConfig()
-    t.deepEqual(configResult, Object.assign({}, config.configDefaults, { pageSize: 1003 }))
+    t.deepEqual(configResult, Object.assign({}, config.getConfigDefaults(), { pageSize: 1003 }))
     process.env.GAIA_PAGE_SIZE = 'abc'
     t.throws(() => config.getConfig(), undefined, 'Should throw error on non-number input')
     delete process.env.GAIA_PAGE_SIZE
 
     process.env.GAIA_WHITELIST = "aaron.id, blankstein.id"
     configResult = config.getConfig()
-    t.deepEqual(configResult, Object.assign({}, config.configDefaults, { whitelist: ['aaron.id', 'blankstein.id'] }))
+    t.deepEqual(configResult, Object.assign({}, config.getConfigDefaults(), { whitelist: ['aaron.id', 'blankstein.id'] }))
 
     delete process.env.GAIA_WHITELIST
 
@@ -36,7 +36,7 @@ export function testConfig() {
     process.env.CONFIG_PATH = `${configDir}/config.0.json`
 
     const configResult = config.getConfig()
-    const configExpected = Object.assign({}, config.configDefaults, { driver: 'azure' },
+    const configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'azure' },
                                          { azCredentials: { accountName: undefined,
                                                             accountKey: undefined }})
 
@@ -50,7 +50,7 @@ export function testConfig() {
     process.env.CONFIG_PATH = `${configDir}/config.1.json`
 
     const configResult = config.getConfig()
-    const configExpected = Object.assign({}, config.configDefaults, { driver: 'azure' },
+    const configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'azure' },
                                          { azCredentials: { accountName: 'pancakes', accountKey: undefined }})
 
     t.deepEqual(configResult, configExpected)
@@ -67,7 +67,7 @@ export function testConfig() {
 
 
     let configResult = config.getConfig()
-    let configExpected: any = Object.assign({}, config.configDefaults, { driver: 'azure' },
+    let configExpected: any = Object.assign({}, config.getConfigDefaults(), { driver: 'azure' },
                                    { azCredentials: { accountName: 'pancakes',
                                                       accountKey: 'apples' }})
 
@@ -76,7 +76,7 @@ export function testConfig() {
     process.env.GAIA_AZURE_ACCOUNT_NAME = 'latkes'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'azure' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'azure' },
                                    { azCredentials: { accountName: 'latkes', accountKey: 'apples' }})
 
 
@@ -89,7 +89,7 @@ export function testConfig() {
 
     process.env.GAIA_DRIVER = 'aws'
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'aws' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'aws' },
                                    { awsCredentials: undefined })
 
     t.deepEqual(configResult, configExpected)
@@ -99,7 +99,7 @@ export function testConfig() {
     process.env.GAIA_S3_SESSION_TOKEN = 'baz'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'aws' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'aws' },
                                    { awsCredentials: {
                                      accessKeyId: 'foo',
                                      secretAccessKey: 'bar',
@@ -110,7 +110,7 @@ export function testConfig() {
     process.env.GAIA_DRIVER = 'google-cloud'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'google-cloud' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'google-cloud' },
                                    { gcCredentials: {} })
 
     t.deepEqual(configResult, configExpected)
@@ -122,7 +122,7 @@ export function testConfig() {
     process.env.GAIA_GCP_CLIENT_PRIVATE_KEY = '5'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'google-cloud' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'google-cloud' },
                                    { gcCredentials: {
                                      email: '1', projectId: '2', keyFilename: '3', credentials: { client_email: '4', private_key: '5' }
                                    } })
@@ -132,7 +132,7 @@ export function testConfig() {
     process.env.GAIA_DRIVER = 'disk'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'disk' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'disk' },
                                    { diskSettings: { storageRootDirectory: undefined } })
 
     t.deepEqual(configResult, configExpected)
@@ -140,7 +140,7 @@ export function testConfig() {
     process.env.GAIA_DISK_STORAGE_ROOT_DIR = '1'
 
     configResult = config.getConfig()
-    configExpected = Object.assign({}, config.configDefaults, { driver: 'disk' },
+    configExpected = Object.assign({}, config.getConfigDefaults(), { driver: 'disk' },
                                    { diskSettings: { storageRootDirectory: '1' } })
 
     t.deepEqual(configResult, configExpected, 'Disk driver reads env vars correctly')

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -19,7 +19,7 @@ import { makeMockedAzureDriver } from './testDrivers/mockTestDrivers'
 import { testPairs, testAddrs } from './common'
 import InMemoryDriver from './testDrivers/InMemoryDriver'
 import { MockAuthTimestampCache } from './MockAuthTimestampCache'
-import { HubConfig } from '../../src/server/config'
+import { HubConfigInterface } from '../../src/server/config'
 
 const TEST_SERVER_NAME = 'test-server'
 const TEST_AUTH_CACHE_SIZE = 10
@@ -222,7 +222,7 @@ function testHttpDriverOption() {
 
 function testHttpWithAzure() {
   const azConfigPath = process.env.AZ_CONFIG_PATH
-  let config : HubConfig & AZ_CONFIG_TYPE = {
+  let config : HubConfigInterface & AZ_CONFIG_TYPE = {
     'azCredentials': {
       'accountName': 'mock-azure',
       'accountKey': 'mock-azure-key'

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -12,15 +12,14 @@ import NodeFetch from 'node-fetch'
 import { makeHttpServer } from '../../src/server/http'
 import DiskDriver from '../../src/server/drivers/diskDriver'
 import { AZ_CONFIG_TYPE } from '../../src/server/drivers/AzDriver'
-import { MakeHttpServerConfig, } from '../../src/server/http'
 import { AuthTimestampCache } from '../../src/server/revocations'
-import { HubServerConfig } from '../../src/server/server'
 import { addMockFetches } from './testDrivers'
 import { makeMockedAzureDriver } from './testDrivers/mockTestDrivers'
 
 import { testPairs, testAddrs } from './common'
 import InMemoryDriver from './testDrivers/InMemoryDriver'
 import { MockAuthTimestampCache } from './MockAuthTimestampCache'
+import { HubConfig } from '../../src/server/config'
 
 const TEST_SERVER_NAME = 'test-server'
 const TEST_AUTH_CACHE_SIZE = 10
@@ -223,7 +222,7 @@ function testHttpDriverOption() {
 
 function testHttpWithAzure() {
   const azConfigPath = process.env.AZ_CONFIG_PATH
-  let config : MakeHttpServerConfig & HubServerConfig & AZ_CONFIG_TYPE = {
+  let config : HubConfig & AZ_CONFIG_TYPE = {
     'azCredentials': {
       'accountName': 'mock-azure',
       'accountKey': 'mock-azure-key'

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -10,9 +10,8 @@ import FetchMock from 'fetch-mock'
 import NodeFetch from 'node-fetch'
 
 import { makeHttpServer } from '../../src/server/http'
-import DiskDriver from '../../src/server/drivers/diskDriver'
+import DiskDriver, { DISK_CONFIG_TYPE } from '../../src/server/drivers/diskDriver'
 import { AZ_CONFIG_TYPE } from '../../src/server/drivers/AzDriver'
-import { AuthTimestampCache } from '../../src/server/revocations'
 import { addMockFetches } from './testDrivers'
 import { makeMockedAzureDriver } from './testDrivers/mockTestDrivers'
 
@@ -191,7 +190,7 @@ function testHttpDriverOption() {
       diskSettings: {
         storageRootDirectory: os.tmpdir()
       }
-    })
+    } as HubConfigInterface & DISK_CONFIG_TYPE)
     t.end()
   })
 


### PR DESCRIPTION
## Goal of PR

Based off of discussion in similar previous PR https://github.com/blockstack/gaia/pull/204.
And issues https://github.com/blockstack/blockstack-browser/pull/1833#issuecomment-480088549 and https://github.com/blockstack/docs.blockstack/issues/198

Remove duplicate config typedefs, generate json schema file on build. 
This does not perform actual on-load schema enforcement that is done in https://github.com/blockstack/gaia/pull/204. 

## Implementation

Shouldn't be any logic changes to hub functionality. 

## Manual Testing

`npm run test`

## Automated Testing

No changes.

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
