### PR TITLE
Remove lint from the `build` / `start` commands. 

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "npm run build && node lib/index.js",
     "start-dev": "ts-node src/index.ts",
-    "build": "npm run lint && tsc && chmod +x lib/index.js",
+    "build": "tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/test.ts"
   },

--- a/hub/package.json
+++ b/hub/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "start": "npm run build && node lib/index.js",
     "start-dev": "ts-node src/index.ts",
-    "build": "npm run lint && tsc && chmod +x lib/index.js",
+    "build": "tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"
   },

--- a/reader/package.json
+++ b/reader/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "npm run build && node lib/index.js",
     "start-dev": "ts-node src/index.ts",
-    "build": "npm run lint && tsc && chmod +x lib/index.js",
+    "build": "tsc && chmod +x lib/index.js",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run lint && NODE_ENV=test nyc node ./test/test.ts"
   },


### PR DESCRIPTION
## Goal of PR

Fix out-of-memory crash and/or super slow hub startup on low spec VM. 

Running `npm run start` for the hub on my low spec VM (1GB memory, 1 vCPU) is either taking a ton of time in the `eslint` script, or getting killed from out-of-memory. Example:
```
$ npm run start

> gaia-hub@2.5.0 start /home/matt/gaia/hub
> npm run build && node lib/index.js
> gaia-hub@2.5.0 build /home/matt/gaia/hub
> npm run lint && tsc && chmod +x lib/index.js
> gaia-hub@2.5.0 lint /home/matt/gaia/hub
> eslint --ext .ts ./src

Killed
npm ERR! code ELIFECYCLE
npm ERR! errno 137
npm ERR! gaia-hub@2.5.0 lint: `eslint --ext .ts ./src`
npm ERR! Exit status 137
npm ERR! 
npm ERR! Failed at the gaia-hub@2.5.0 lint script.
```

Note: eslint performs smarter checks w/ typescript integration, and so is much more resource intensive than it used to be. 

## Implementation

Remove the lint step from the `build` script which is called by the `start` script. This helps the docker startup as well which runs the same command. 

The linting is still performed in tests which get ran on PRs / circleCI:
```json
    "lint": "eslint --ext .ts ./src",
    "test": "npm run lint && NODE_ENV=test nyc node ./test/test.ts"
```

## Manual Testing

Run `npm run start` or `npm run build` to ensure those still work, and also don't run linting.

Run `npm run test` to ensure it runs linting. 

## Automated Testing

No changes. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
