### PR TITLE
Schema validation warnings

### DIFF
--- a/hub/config-schema.json
+++ b/hub/config-schema.json
@@ -157,15 +157,18 @@
         },
         "serverName": {
             "default": "gaia-0",
+            "description": "Domain name used for auth/signing challenges. \nIf `requireCorrectHubUrl` is true then this must match the hub url in an auth payload.",
             "type": "string"
         },
         "validHubUrls": {
+            "description": "If `requireCorrectHubUrl` is true then the hub specified in an auth payload can also be\ncontained within in array.",
             "items": {
                 "type": "string"
             },
             "type": "array"
         },
         "whitelist": {
+            "description": "List of ID addresses allowed to use this hub. Specifying this makes the hub private \nand only accessible to the specified addresses. Leaving this unspecified makes the hub \npublicly usable by any ID.",
             "items": {
                 "type": "string"
             },

--- a/hub/config-schema.json
+++ b/hub/config-schema.json
@@ -1,7 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
     "properties": {
         "argsTransport": {
+            "additionalProperties": false,
             "properties": {
                 "colorize": {
                     "default": true,
@@ -38,6 +40,7 @@
             "type": "integer"
         },
         "awsCredentials": {
+            "additionalProperties": false,
             "description": "Required if `driver` is `aws`",
             "properties": {
                 "accessKeyId": {
@@ -56,6 +59,7 @@
             "type": "object"
         },
         "azCredentials": {
+            "additionalProperties": false,
             "description": "Required if `driver` is `azure`",
             "properties": {
                 "accountKey": {
@@ -76,6 +80,7 @@
             "type": "string"
         },
         "diskSettings": {
+            "additionalProperties": false,
             "description": "Required if `driver` is `disk`",
             "properties": {
                 "storageRootDirectory": {
@@ -94,9 +99,11 @@
             "type": "string"
         },
         "gcCredentials": {
+            "additionalProperties": false,
             "description": "Required if `driver` is `google-cloud`",
             "properties": {
                 "credentials": {
+                    "additionalProperties": false,
                     "properties": {
                         "client_email": {
                             "type": "string"
@@ -132,6 +139,7 @@
             "type": "integer"
         },
         "proofsConfig": {
+            "additionalProperties": false,
             "properties": {
                 "proofsRequired": {
                     "default": 0,

--- a/hub/config.sample.json
+++ b/hub/config.sample.json
@@ -1,34 +1,13 @@
 {
-  "servername": "hub",
-  "port": "3000",
-  "driver": "disk",
-  "bucket": "hub",
-  "readURL": "hub",
-  "cacheControl": "public, max-age=1",
-  "pageSize": 20,
-  "diskSettings": {
-    "storageRootDirectory": "/tmp/gaia-disk"
-  },
-  "awsCredentials": {
-    "accessKeyId": "",
-    "secretAccessKey": ""
-  },
-
-  "proofsConfig": {
-    "proofsRequired" : 0
-  },
-
-  "azCredentials": {
-    "accountName": "",
-    "accountKey": ""
-  },
-
+  "port": 3000,
+  "driver": "",
+  "bucket": "",
+  "readURL": "",
   "argsTransport": {
     "level": "debug",
     "handleExceptions": true,
-    "stringify": true,
     "timestamp": true,
-    "colorize": true,
+    "colorize": false,
     "json": true
   }
 }

--- a/hub/etc/config.sample.disk.json
+++ b/hub/etc/config.sample.disk.json
@@ -1,21 +1,15 @@
 {
-  "servername": "localhost",
-  "port": 4000,
+  "port": 3000,
   "driver": "disk",
-  "readURL": "http://localhost:4001/",
-  "proofsConfig": {
-    "proofsRequired" : 0
-  },
-  "diskSettings": {
-     "storageRootDirectory": "/tmp/gaia-disk"
-  },
-  "pageSize": 20,
+  "readURL": "",
   "argsTransport": {
     "level": "debug",
     "handleExceptions": true,
-    "stringify": true,
     "timestamp": true,
     "colorize": false,
     "json": true
+  },
+  "diskSettings": {
+    "storageRootDirectory": "/tmp/gaia-disk"
   }
 }

--- a/hub/etc/config.sample.gcloud.json
+++ b/hub/etc/config.sample.gcloud.json
@@ -1,22 +1,16 @@
 {
-  "servername": "localhost",
-  "port": 4000,
-  "driver": "disk",
-  "readURL": "http://localhost:4000/",
-  "proofsConfig": {
-    "proofsRequired" : 0
-  },
-  "pageSize": 20,
+  "port": 3000,
+  "driver": "google-cloud",
   "bucket": "YOUR_BUCKET_NAME",
-  "gcCredentials": {
-     "keyFilename": "YOUR_KEY_FILE_PATH"
-  },
+  "readURL": "",
   "argsTransport": {
     "level": "debug",
     "handleExceptions": true,
-    "stringify": true,
     "timestamp": true,
     "colorize": false,
     "json": true
+  },
+  "gcCredentials": {
+     "keyFilename": "YOUR_KEY_FILE_PATH"
   }
 }

--- a/hub/etc/config.sample.s3.json
+++ b/hub/etc/config.sample.s3.json
@@ -1,23 +1,17 @@
 {
-  "servername": "localhost",
-  "port": 4000,
+  "port": 3000,
   "driver": "aws",
-  "readURL": "https://YOUR_BUCKET_NAME.s3.amazonaws.com/",
-  "proofsConfig": {
-    "proofsRequired" : 0
-  },
-  "pageSize": 20,
   "bucket": "YOUR_BUCKET_NAME",
-  "awsCredentials": {
-     "accessKeyId": "YOUR_ACCESS_KEY",
-     "secretAccessKey": "YOUR_SECRET_KEY"
-  },
+  "readURL": "https://YOUR_BUCKET_NAME.s3.amazonaws.com/",
   "argsTransport": {
     "level": "debug",
     "handleExceptions": true,
-    "stringify": true,
     "timestamp": true,
     "colorize": false,
     "json": true
+  },
+  "awsCredentials": {
+     "accessKeyId": "YOUR_ACCESS_KEY",
+     "secretAccessKey": "YOUR_SECRET_KEY"
   }
 }

--- a/hub/package.json
+++ b/hub/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@azure/storage-blob": "^10.3.0",
     "@google-cloud/storage": "^2.4.2",
+    "ajv": "^6.10.0",
     "aws-sdk": "^2.413.0",
     "bitcoinjs-lib": "^4.0.3",
     "blockstack": "^18.3.0",
@@ -57,7 +58,7 @@
     "start": "npm run build && node lib/index.js",
     "dev": "ts-node src/index.ts",
     "build": "tsc && chmod +x lib/index.js && npm run build-schema",
-    "build-schema": "typescript-json-schema tsconfig.json HubConfig --required --refs=false -o config-schema.json",
+    "build-schema": "typescript-json-schema tsconfig.json HubConfig --required --noExtraProps --refs=false -o config-schema.json",
     "lint": "eslint --ext .ts ./src",
     "test": "npm run build && npm run lint && NODE_ENV=test nyc node ./test/src/index.ts"
   },

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
+import path from 'path'
 import { makeHttpServer } from './server/http'
-import { getConfig } from './server/config'
+import { getConfig, validateConfigSchema } from './server/config'
 import { logger } from './server/utils'
 
+const appRootDir = path.dirname(path.resolve(__dirname))
+const schemaFilePath = path.join(appRootDir, 'config-schema.json')
+
 const conf = getConfig()
+validateConfigSchema(schemaFilePath, conf)
 
 const { app, driver } = makeHttpServer(conf)
 

--- a/hub/src/server/config.ts
+++ b/hub/src/server/config.ts
@@ -111,6 +111,10 @@ class HubConfig implements HubConfigInterface {
   argsTransport? = new LoggingConfig();
   proofsConfig? = new ProofCheckerConfig();
   requireCorrectHubUrl? = false;
+  /**
+   * Domain name used for auth/signing challenges. 
+   * If `requireCorrectHubUrl` is true then this must match the hub url in an auth payload. 
+   */
   serverName? = 'gaia-0';
   bucket? = 'hub';
   /**
@@ -133,11 +137,18 @@ class HubConfig implements HubConfigInterface {
 
   driver = undefined as DriverName;
 
-  // --- Optional values that default to undefined & unused
+  /**
+   * List of ID addresses allowed to use this hub. Specifying this makes the hub private 
+   * and only accessible to the specified addresses. Leaving this unspecified makes the hub 
+   * publicly usable by any ID. 
+   */
   whitelist?: string[]
   readURL?: string;
+  /**
+   * If `requireCorrectHubUrl` is true then the hub specified in an auth payload can also be
+   * contained within in array.  
+   */
   validHubUrls?: string[];
-  // ---
 
 }
 

--- a/hub/src/server/config.ts
+++ b/hub/src/server/config.ts
@@ -235,7 +235,11 @@ export function getConfigDefaults(): HubConfigInterface {
   return configDefaults
 } 
 
-export function validateConfigSchema(schemaFilePath: string, configObj: any) {
+export function validateConfigSchema(
+  schemaFilePath: string, 
+  configObj: any, 
+  warnCallback: (msg: string) => void = console.error
+) {
   try {
     const ajv = new Ajv({
       allErrors: true,
@@ -244,14 +248,14 @@ export function validateConfigSchema(schemaFilePath: string, configObj: any) {
       errorDataPath: 'property'
     })
     if (!fs.existsSync(schemaFilePath)) {
-      console.error(`Could not find config schema file at ${schemaFilePath}`)
+      warnCallback(`Could not find config schema file at ${schemaFilePath}`)
       return
     }
     let schemaJson: any
     try {
       schemaJson = JSON.parse(fs.readFileSync(schemaFilePath, { encoding: 'utf8' }))
     } catch (error) {
-      console.error(`Error reading config schema JSON file: ${error}`)
+      warnCallback(`Error reading config schema JSON file: ${error}`)
       return
     }
     const valid = ajv.validate(schemaJson, configObj)
@@ -259,10 +263,10 @@ export function validateConfigSchema(schemaFilePath: string, configObj: any) {
       const errorText = ajv.errorsText(ajv.errors, {
         dataVar: 'config'
       })
-      console.error(`Config schema validation warning: ${errorText}`)
+      warnCallback(`Config schema validation warning: ${errorText}`)
     }
   } catch (error) {
-    console.error(`Error validating config schema JSON file: ${error}`)
+    warnCallback(`Error validating config schema JSON file: ${error}`)
   }
 }
 

--- a/hub/test/data/invalid-schema-def.json
+++ b/hub/test/data/invalid-schema-def.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": 123,
+  "broken": { }
+}


### PR DESCRIPTION
## Goal of PR

From https://github.com/blockstack/gaia/pull/204#pullrequestreview-223293778

> While recently setting up a personal gaia hub I ran into a couple hiccups that required briefly going through the config related code. I think Hank just ran into similar situation. I think config schema checking that showed console warnings would be useful for this

## Implementation

Loosely based off original PR https://github.com/blockstack/gaia/pull/204

Uses the most popular json schema validation lib [`ajv`](https://www.npmjs.com/package/ajv). 

Outputs warnings for:
* Missing config params - only a couple are required by the schema right now. 
* Params that are of the wrong type or out of range. 
* (Most useful feature) "Extra" params found in the config, which are almost always typos or similarly accidental incorrect usage. 


### Config Warning Examples

```json
{
  "driver": "azure",
  "port": 12345,
  "whitelist": { "1Nw25PemCRv24UQAcZdaj4uD11nkTCWRTE": true }
}
```
\> `Config schema validation warning: config.whitelist should be array`

---

```json
{
  "driver": "microsoft",
  "port": 12345
}
```
\> `Config schema validation warning: config.driver should be equal to one of the allowed values`

---

```json
{
  "driver": "microsoft",
  "port": 3837659,
  "bucketTitle": "mybucket"
}
```
\> `Config schema validation warning: config['bucketTitle'] is an invalid additional property, config.driver should be equal to one of the allowed values, config.port should be <= 65535`

## Automated Testing

Full test coverage for schema validation warnings. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
