### PR TITLE
Return error 409 on concurrent writes error

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,11 @@ The bearer token's content and generation is described in
 the [access control](#address-based-access-control) section of this
 document.
 
+Some backend storage drivers will return error `409 Conflict` when a 
+concurrent write to the same file path occurs. This can be handled with
+a retry. Other storage drivers tend to use `last writer wins` conflict
+resolution and will not throw an error. 
+
 ---
 
 ```

--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1]
+### Fixed
+- Concurrent writes to the same file using the Azure driver now returns
+  error 409 Conflict rather than 500 Internal Server Error. 
+
 ## [2.5.0]
 ### Added
 - Added support for deleting files using HTTP DELETE requests to the

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -2,7 +2,7 @@
 
 import * as azure from '@azure/storage-blob'
 import { logger } from '../utils'
-import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
+import { BadPathError, InvalidInputError, DoesNotExist, ConflictError } from '../errors'
 import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs } from '../driverModel'
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
 
@@ -173,6 +173,9 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
       )
     } catch (error) {
       logger.error(`failed to store ${azBlob} in ${this.bucket}: ${error}`)
+      if (error.body && error.body.Code === 'InvalidBlockList') {
+        throw new ConflictError('Likely failed due to concurrent PUTs to the same file')
+      }
       throw new Error('Azure storage failure: failed to store' +
         ` ${azBlob} in container ${this.bucket}: ${error}`)
     }

--- a/hub/src/server/errors.ts
+++ b/hub/src/server/errors.ts
@@ -23,6 +23,13 @@ export class DoesNotExist extends Error {
   }
 }
 
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
 export class BadPathError extends Error {
   constructor (message: string) {
     super(message)

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -69,6 +69,8 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
           writeResponse(res, { message: err.message, error: err.name  }, 403)
         } else if (err instanceof errors.NotEnoughProofError) {
           writeResponse(res, { message: err.message, error: err.name  }, 402)
+        } else if (err instanceof errors.ConflictError) {
+          writeResponse(res, { message: err.message, error: err.name  }, 409)
         } else {
           writeResponse(res, { message: 'Server Error' }, 500)
         }

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -252,14 +252,18 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
             contentType: 'text/plain; charset=utf-8',
             contentLength: 100
           })
-          await utils.timeout(1)
+          await utils.timeout(10)
           stream1.end()
-          await utils.timeout(100)
+          await utils.timeout(10)
           stream2.end()
           const [ readEndpoint ] = await Promise.all([writeRequest1, writeRequest2])
           resp = await fetch(readEndpoint)
           resptxt = await resp.text()
-          t.equal(resptxt, 'xyz sample content 2', 'Concurrent writes resulted in an unconditional update (last writer wins)')
+          if (resptxt === 'xyz sample content 2' || resptxt === 'abc sample content 1') {
+            t.ok(resptxt, 'Concurrent writes resulted in conflict resolution at the storage provider')
+          } else {
+            t.fail(`Concurrent writes resulted in mangled data: ${resptxt}`)
+          }
         } catch (error) {
           if (error instanceof ConflictError) {
             t.pass('Concurrent writes resulted in ConflictError')

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -8,16 +8,17 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
-import { Readable, Writable } from 'stream'
+import { Readable, Writable, PassThrough } from 'stream'
 import InMemoryDriver from './testDrivers/InMemoryDriver'
 import { DriverModel, DriverModelTestMethods } from '../../src/server/driverModel'
 import { ListFilesResult } from '../../src/server/driverModel'
+import * as utils from '../../src/server/utils'
 
 import DiskDriver from '../../src/server/drivers/diskDriver'
 
 import * as mockTestDrivers from './testDrivers/mockTestDrivers'
 import * as integrationTestDrivers from './testDrivers/integrationTestDrivers'
-import { BadPathError, DoesNotExist } from '../../src/server/errors'
+import { BadPathError, DoesNotExist, ConflictError } from '../../src/server/errors'
 
 export function addMockFetches(fetchLib: FetchMock.FetchMockSandbox, prefix: any, dataMap: {key: string, data: string}[]) {
   dataMap.forEach(item => {
@@ -223,6 +224,48 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           t.pass('List files with invalid page data should fail or return no results')
         } catch (error) {
           t.pass('List files with invalid page data should have failed')
+        }
+
+        // test concurrent writes to same file
+        try {
+          const concurrentTestFile = 'concurrent_file_test'
+
+          const stream1 = new PassThrough()
+          stream1.write('abc sample content 1', 'utf8')
+
+          const writeRequest1 = driver.performWrite({
+            path: concurrentTestFile,
+            storageTopLevel: topLevelStorage,
+            stream: stream1,
+            contentType: 'text/plain; charset=utf-8',
+            contentLength: 100
+          });
+
+          const stream2 = new PassThrough()
+          stream2.write('xyz sample content 2', 'utf8')
+
+          await utils.timeout(1)
+          const writeRequest2 = driver.performWrite({
+            path: concurrentTestFile,
+            storageTopLevel: topLevelStorage,
+            stream: stream2,
+            contentType: 'text/plain; charset=utf-8',
+            contentLength: 100
+          })
+          await utils.timeout(1)
+          stream1.end()
+          await utils.timeout(100)
+          stream2.end()
+          const [ readEndpoint ] = await Promise.all([writeRequest1, writeRequest2])
+          resp = await fetch(readEndpoint)
+          resptxt = await resp.text()
+          t.equal(resptxt, 'xyz sample content 2', 'Concurrent writes resulted in an unconditional update (last writer wins)')
+        } catch (error) {
+          if (error instanceof ConflictError) {
+            t.pass('Concurrent writes resulted in ConflictError')
+          } else {
+            t.error(error, 'Unexpected error during concurrent writes')
+          }
         }
 
         try {

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -68,6 +68,14 @@ export function testHttpWithInMemoryDriver() {
       t.equal(files.entries.length, 1, 'Should return one file')
       t.equal(files.entries[0], 'helloWorld', 'Should be helloworld')
       t.ok(files.hasOwnProperty('page'), 'Response is missing a page')
+
+      inMemoryDriver.filesInProgress.set(`${address}/helloWorld`, null)
+      await request(app).post(path)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(409)
+
       t.end()
 
     } finally {


### PR DESCRIPTION
## Goal of PR

https://github.com/blockstack/gaia/issues/228
Fix 500 error during concurrent writes to same file for some drivers. 

## Implementation

Error `409 Conflict` is returned. 

Azure is the only service that errors during this situation. All others perform conflict resolution on their end, usually `last writer wins`. 

## Automated Testing

Implemented integration tests for concurrent writes, performed on all drivers. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
