### PR TITLE
Set lrucache `noDisposeOnSet`

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3]
+### Fixed
+- LRUCache count evictions is no longer overestimated. 
+
 ## [2.5.2]
 ### Fixed
 - Concurrent writes to the same file using the Azure driver now returns

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/hub/src/server/revocations.ts
+++ b/hub/src/server/revocations.ts
@@ -20,6 +20,7 @@ export class AuthTimestampCache {
     this.currentCacheEvictions = 0
     this.cache = new LRUCache<string, number>({ 
       max: maxCacheSize, 
+      noDisposeOnSet: true, 
       dispose: () => {
         this.currentCacheEvictions++
       }

--- a/hub/test/src/testServer.ts
+++ b/hub/test/src/testServer.ts
@@ -256,10 +256,12 @@ export function testServer() {
         const challengeText = auth.getChallengeText(TEST_SERVER_NAME)
         let authPart = auth.V1Authentication.makeAuthPart(testPairs[i], challengeText)
         let authorization = `bearer ${authPart}`
-        await server.handleRequest(testAddrs[i], '/foo/bar', 
-                                  { 'content-type' : 'text/text',
-                                    'content-length': 400,
-                                    authorization }, getJunkData())
+        for (let f = 0; f < 3; f++) {
+          await server.handleRequest(testAddrs[i], '/foo/bar', 
+                                    { 'content-type' : 'text/text',
+                                      'content-length': 400,
+                                      authorization }, getJunkData())
+        }
       }
 
       t.equal(server.authTimestampCache.currentCacheEvictions, 6, 'Auth cache should have correct number of evictions')


### PR DESCRIPTION
## Goal of PR

Fix https://github.com/blockstack/gaia/issues/232
> We should set the `noDisposeOnSet` option in the LRUCache initialization (see: https://www.npmjs.com/package/lru-cache#options).
> 
> The way that we currently count evictions will be a large overestimate because of this.


## Implementation

Set flag. 

## Automated Testing

Added tests to reproduce bug and confirm fix. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
