### PR TITLE
ReadFile driver operation primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ performWrite (options: { path, storageToplevel, contentType,
 /**
  * Deletes a file. Throws a `DoesNotExist` if the file does not exist. 
  * @param { String } options.path - path of the file
- * @param { String } options.storageToplevel - the top level directory
+ * @param { String } options.storageTopLevel - the top level directory
  * @param { String } options.contentType - the HTTP content-type of the file
  * @returns {Promise}
  */
@@ -286,6 +286,20 @@ performDelete (options: { path, storageToplevel })
  */
 performRename (options: { path, storageTopLevel,
                           newPath, newStorageTopLevel })
+
+/**
+ * Returns an object with a NodeJS stream.Readable for the file content
+ * and metadata about the file. 
+ * @param { String } options.path - path of the file
+ * @param { String } options.storageTopLevel - the top level directory
+ * @returns { Promise {
+ *  data: Readable,
+ *  lastModifiedDate: number,
+ *  contentLength: number,
+ *  contentType: string
+ * }}
+ */
+performRead (options: { path, storageTopLevel })
 
 /**
  * Retrieves metadata for a given file. 

--- a/hub/src/server/driverModel.ts
+++ b/hub/src/server/driverModel.ts
@@ -20,6 +20,16 @@ export interface PerformDeleteArgs {
   storageTopLevel: string;
 }
 
+export interface PerformReadArgs {
+  path: string;
+  storageTopLevel: string;
+}
+
+export interface ReadResult extends Required<StatResult> {
+  data: Readable;
+  exists: true
+}
+
 export interface PerformStatArgs {
   path: string;
   storageTopLevel: string;
@@ -45,6 +55,7 @@ export interface DriverModel {
   performDelete(args: PerformDeleteArgs): Promise<void>;
   performRename(args: PerformRenameArgs): Promise<void>;
   performStat(args: PerformStatArgs): Promise<StatResult>;
+  performRead(args: PerformReadArgs): Promise<ReadResult>;
   listFiles(storageTopLevel: string, page?: string): Promise<ListFilesResult>;
   ensureInitialized(): Promise<void>;
   dispose(): Promise<void>;

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -219,7 +219,8 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     const blockBlobURL = azure.BlockBlobURL.fromBlobURL(blobURL)
 
     try {
-      const downloadResult = await blockBlobURL.download(azure.Aborter.none, 0, undefined)
+      const offset = 0
+      const downloadResult = await blockBlobURL.download(azure.Aborter.none, offset)
       const dataStream = downloadResult.readableStreamBody as Readable
       let lastModified: number | undefined
       if (downloadResult.lastModified) {

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -3,8 +3,9 @@
 import * as azure from '@azure/storage-blob'
 import { logger } from '../utils'
 import { BadPathError, InvalidInputError, DoesNotExist, ConflictError } from '../errors'
-import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, PerformStatArgs, StatResult } from '../driverModel'
+import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, PerformStatArgs, StatResult, PerformReadArgs, ReadResult } from '../driverModel'
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
+import { Readable } from 'stream'
 
 export interface AZ_CONFIG_TYPE {
   azCredentials: {
@@ -205,6 +206,41 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
       logger.error(`failed to delete ${azBlob} in ${this.bucket}: ${error}`)
       /* istanbul ignore next */
       throw new Error('Azure storage failure: failed to delete' +
+        ` ${azBlob} in container ${this.bucket}: ${error}`)
+    }
+  }
+  
+  async performRead(args: PerformReadArgs): Promise<ReadResult> {
+    if (!AzDriver.isPathValid(args.path)) {
+      throw new BadPathError('Invalid Path')
+    }
+    const azBlob = `${args.storageTopLevel}/${args.path}`
+    const blobURL = azure.BlobURL.fromContainerURL(this.container, azBlob)
+    const blockBlobURL = azure.BlockBlobURL.fromBlobURL(blobURL)
+
+    try {
+      const downloadResult = await blockBlobURL.download(azure.Aborter.none, 0, undefined)
+      const dataStream = downloadResult.readableStreamBody as Readable
+      let lastModified: number | undefined
+      if (downloadResult.lastModified) {
+        lastModified = Math.round(downloadResult.lastModified.getTime() / 1000)
+      }
+      const result: ReadResult = {
+        exists: true,
+        contentLength: downloadResult.contentLength,
+        contentType: downloadResult.contentType,
+        lastModifiedDate: lastModified,
+        data: dataStream
+      }
+      return result
+    } catch (error) {
+      if (error.statusCode === 404) {
+        throw new DoesNotExist('File does not exist')
+      }
+      /* istanbul ignore next */
+      logger.error(`failed to read ${azBlob} in ${this.bucket}: ${error}`)
+      /* istanbul ignore next */
+      throw new Error('Azure storage failure: failed to read' +
         ` ${azBlob} in container ${this.bucket}: ${error}`)
     }
   }

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -168,6 +168,76 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       }
 
       if (!mockTest) {
+        // test file read
+        try {
+          const readTestFile = 'read_test_file.txt'
+          const stream = new PassThrough()
+          stream.end('Hello read test!')
+          const dateNow1 = Math.round(Date.now() / 1000)
+          await driver.performWrite({
+            path: readTestFile,
+            storageTopLevel: topLevelStorage,
+            stream: stream,
+            contentType: 'text/plain; charset=utf-8',
+            contentLength: 100
+          })
+          const readResult = await driver.performRead({
+            path: readTestFile,
+            storageTopLevel: topLevelStorage
+          })
+          const dataBuffer = await utils.readStream(readResult.data)
+          const dataStr = dataBuffer.toString('utf8')
+          t.equal(dataStr, 'Hello read test!')
+          t.equal(readResult.exists, true, 'File stat should return exists after write')
+          t.equal(readResult.contentLength, 16, 'File stat should have correct content length')
+          t.equal(readResult.contentType, "text/plain; charset=utf-8", 'File stat should have correct content type')
+          const dateDiff = Math.abs(readResult.lastModifiedDate - dateNow1)
+          t.equal(dateDiff < 10, true, `File stat last modified date is not within range, diff: ${dateDiff} -- ${readResult.lastModifiedDate} vs ${dateNow1}`)
+
+        } catch (error) {
+          t.error(error, 'Error performing file read test')
+        }
+
+        // test file read on non-existent file
+        try {
+          const nonExistentFile = 'read_none.txt'
+          const statResult = await driver.performRead({
+            path: nonExistentFile,
+            storageTopLevel: topLevelStorage
+          })
+          t.equal(statResult.exists, false, 'File read should throw not exist')
+        } catch (error) {
+          t.pass('Should fail to performRead on non-existent file')
+          if (!(error instanceof DoesNotExist)) {
+            t.equal(error.constructor.name, 'DoesNotExist', 'Should throw DoesNotExist trying to performRead on non-existent file')
+          }
+        }
+
+        // test file read on invalid path
+        try {
+          await driver.performRead({path: '../foo.js', storageTopLevel: topLevelStorage})
+          t.fail('Should have thrown performing file read with invalid path')
+        }
+        catch (error) {
+          t.pass('Should fail to performStat on invalid path')
+          if (!(error instanceof BadPathError)) {
+            t.equal(error.constructor.name, 'BadPathError', 'Should throw BadPathError trying to performRead on directory')
+          }
+        }
+
+        // test file read on subdirectory
+        try {
+          const result = await driver.performRead({path: fileSubDir, storageTopLevel: topLevelStorage})
+          t.equal(result.exists, false, 'performRead on a directory should return not exists')
+        } catch (error) {
+          t.pass('Should fail to performRead on directory')
+          if (!(error instanceof DoesNotExist)) {
+            t.equal(error.constructor.name, 'DoesNotExist', 'Should throw DoesNotExist trying to performRead on directory')
+          }
+        }
+      }
+
+      if (!mockTest) {
         // test file stat
         try {
           const statTestFile = 'stat_test.txt'


### PR DESCRIPTION
## Goal of PR

https://github.com/blockstack/gaia/issues/220, https://github.com/blockstack/gaia/issues/240

Implement read file support in all drivers. Will be used for the incrementing index file version keys as part of the collections historical naming scheme. 

## Implementation

`performRead` returns same information as `performStat` but with an added NodeJS `stream.Readable` data field. Extra precaution taken to avoid buffering an entire file stream in memory -- allows the future invocations to perform streaming operations with appropriate back-pressure handling. For example, using a streaming json util that could find and increment a key-val pair on a theoretical larger-than-memory index.json file. 

## Manual Testing

`DRIVER_CONFIG_TEST_DATA=configs/drivers.json npm test`

## Automated Testing

Full integration testing implement for all supported drivers. As well as various error handling. All drivers showing behavioral consistency.

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
