### PR TITLE
Implement mutex around file mutation http handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,13 @@ can be configured via the [config.json](#configuration-files).
 # Driver model
 
 Gaia hub drivers are fairly simple. The biggest requirement is the ability
-to fulfill the _write-to/read-from_ URL guarantee. As currently implemented
-a gaia hub driver must implement the following two functions:
+to fulfill the _write-to/read-from_ URL guarantee. 
+
+A driver can expect that each of its functions will be mutexed by a path. 
+As in, no function will be invoked concurrently with a given unique path. 
+
+As currently implemented
+a gaia hub driver must implement the following functions:
 
 ```javascript
 /**

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ can be configured via the [config.json](#configuration-files).
 Gaia hub drivers are fairly simple. The biggest requirement is the ability
 to fulfill the _write-to/read-from_ URL guarantee. 
 
-A driver can expect that each of its functions will be mutexed by a path. 
-As in, no function will be invoked concurrently with a given unique path. 
+A driver can expect that two modification operations to the same path will be mutually exclusive. 
+No writes, renames, or deletes to the same path will be concurrent.
 
 As currently implemented
 a gaia hub driver must implement the following functions:

--- a/admin/.eslintrc.js
+++ b/admin/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
     "new-cap": 0,
     "brace-style": 2,
     "semi": [2, "never"],
-    "valid-jsdoc": ["error"],
 
     "@typescript-eslint/indent": [2, 2, {
       "FunctionDeclaration": { "parameters": "first" },

--- a/hub/.eslintrc.js
+++ b/hub/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
     "new-cap": 0,
     "brace-style": 2,
     "semi": [2, "never"],
-    "valid-jsdoc": ["error"],
 
     "@typescript-eslint/indent": [2, 2, {
       "FunctionDeclaration": { "parameters": "first" },

--- a/hub/src/server/drivers/GcDriver.ts
+++ b/hub/src/server/drivers/GcDriver.ts
@@ -3,7 +3,7 @@ import { Storage, File } from '@google-cloud/storage'
 import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
 import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, StatResult, PerformStatArgs, PerformReadArgs, ReadResult } from '../driverModel'
 import { DriverStatics, DriverModel, DriverModelTestMethods } from '../driverModel'
-import { pipeline, logger } from '../utils'
+import { pipelineAsync, logger } from '../utils'
 
 export interface GC_CONFIG_TYPE {
   gcCredentials?: {
@@ -189,7 +189,7 @@ class GcDriver implements DriverModel, DriverModelTestMethods {
     })
 
     try {
-      await pipeline(args.stream, fileWriteStream)
+      await pipelineAsync(args.stream, fileWriteStream)
       logger.debug(`storing ${filename} in bucket ${this.bucket}`)
     } catch (error) {
       logger.error(`failed to store ${filename} in bucket ${this.bucket}`)

--- a/hub/src/server/drivers/diskDriver.ts
+++ b/hub/src/server/drivers/diskDriver.ts
@@ -3,7 +3,7 @@ import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
 import Path from 'path'
 import { ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, PerformStatArgs, StatResult, PerformReadArgs, ReadResult } from '../driverModel'
 import { DriverStatics, DriverModel } from '../driverModel'
-import { pipeline, logger } from '../utils'
+import { pipelineAsync, logger } from '../utils'
 
 export interface DISK_CONFIG_TYPE { 
   diskSettings: { storageRootDirectory?: string },
@@ -199,7 +199,7 @@ class DiskDriver implements DriverModel {
     await this.mkdirs(absdirname)
 
     const writePipe = fs.createWriteStream(absoluteFilePath, { mode: 0o600, flags: 'w' })
-    await pipeline(args.stream, writePipe)
+    await pipelineAsync(args.stream, writePipe)
 
 
     const contentTypeDirPath = Path.dirname(contentTypeFilePath)

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -80,13 +80,18 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
       }
     }
 
-    if (!asyncMutex.tryAcquire(endpoint, handleRequest)) {
-      const errMsg = `Concurrent operation (store) attempted on ${endpoint}`
-      logger.error(errMsg)
-      writeResponse(res, { 
-        message: errMsg, 
-        error: errors.ConflictError.name 
-      }, 409)
+    try {
+      if (!asyncMutex.tryAcquire(endpoint, handleRequest)) {
+        const errMsg = `Concurrent operation (store) attempted on ${endpoint}`
+        logger.error(errMsg)
+        writeResponse(res, { 
+          message: errMsg, 
+          error: errors.ConflictError.name 
+        }, 409)
+      }
+    } catch (err) {
+      logger.error(err)
+      writeResponse(res, { message: 'Server Error' }, 500)
     }
 
   })
@@ -125,14 +130,20 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
       }
     }
 
-    if (!asyncMutex.tryAcquire(endpoint, handleRequest)) {
-      const errMsg = `Concurrent operation (delete) attempted on ${endpoint}`
-      logger.error(errMsg)
-      writeResponse(res, { 
-        message: errMsg, 
-        error: errors.ConflictError.name 
-      }, 409)
+    try {
+      if (!asyncMutex.tryAcquire(endpoint, handleRequest)) {
+        const errMsg = `Concurrent operation (delete) attempted on ${endpoint}`
+        logger.error(errMsg)
+        writeResponse(res, { 
+          message: errMsg, 
+          error: errors.ConflictError.name 
+        }, 409)
+      }
+    } catch (err) {
+      logger.error(err)
+      writeResponse(res, { message: 'Server Error' }, 500)
     }
+
   })
 
   app.post(

--- a/hub/src/server/utils.ts
+++ b/hub/src/server/utils.ts
@@ -84,9 +84,7 @@ export class AsyncMutexScope {
     if (this._opened.has(id)) {
       return false
     }
-
-    // Wrap in Promise.resolve to ensure potential synchronous errors are not throw within this function. 
-    const owner = Promise.resolve().then(() => spawnOwner())
+    const owner = spawnOwner()
     this._opened.add(id)
     owner.finally(() => {
       this._opened.delete(id)

--- a/hub/src/server/utils.ts
+++ b/hub/src/server/utils.ts
@@ -64,15 +64,9 @@ export function timeout(milliseconds: number): Promise<void> {
 }
 
 
-export interface AsyncMutex {
-  id: string;
-  owner: Promise<void>;
-  alive: boolean;
-}
-
 export class AsyncMutexScope {
 
-  private readonly _opened: Map<string, AsyncMutex> = new Map()
+  private readonly _opened = new Set<string>()
 
   public get openedCount() {
     return this._opened.size
@@ -93,15 +87,9 @@ export class AsyncMutexScope {
 
     // Wrap in Promise.resolve to ensure potential synchronous errors are not throw within this function. 
     const owner = Promise.resolve().then(() => spawnOwner())
-    const mutex: AsyncMutex = {
-      id: id,
-      owner: owner,
-      alive: true
-    }
-    this._opened.set(id, mutex)
+    this._opened.add(id)
     owner.finally(() => {
       this._opened.delete(id)
-      mutex.alive = false
     })
     return true
   }

--- a/hub/src/server/utils.ts
+++ b/hub/src/server/utils.ts
@@ -84,11 +84,26 @@ export class AsyncMutexScope {
     if (this._opened.has(id)) {
       return false
     }
-    const owner = spawnOwner()
+
+    // Lock before invoking the given func to prevent potential synchronous 
+    // reentrant locking attempts. 
     this._opened.add(id)
-    owner.finally(() => {
+    
+    try {
+      const owner = spawnOwner()
+      // If spawnOwner does not throw an error then we can safely attach the
+      // unlock to the returned Promise. Once the Promise has evaluated (with or 
+      // without error), we unlock. 
+      owner.finally(() => {
+        this._opened.delete(id)
+      })
+    } catch (error) {
+      // If spawnOwner throws a synchronous error then unlock and re-throw the
+      // error for the caller to handle. This is okay in js because re-throwing
+      // an error preserves the original error call stack. 
       this._opened.delete(id)
-    })
+      throw error
+    }
     return true
   }
 

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -18,12 +18,110 @@ import { testPairs, testAddrs } from './common'
 import InMemoryDriver from './testDrivers/InMemoryDriver'
 import { MockAuthTimestampCache } from './MockAuthTimestampCache'
 import { HubConfigInterface } from '../../src/server/config'
+import { PassThrough } from 'stream';
 
 const TEST_SERVER_NAME = 'test-server'
 const TEST_AUTH_CACHE_SIZE = 10
 
 
 export function testHttpWithInMemoryDriver() {
+
+  test('reject concurrent requests to same resource (InMemory driver)', async (t) => {
+    const inMemoryDriver = await InMemoryDriver.spawn()
+    try {
+      const makeResult = makeHttpServer({ driverInstance: inMemoryDriver, serverName: TEST_SERVER_NAME, authTimestampCacheSize: TEST_AUTH_CACHE_SIZE })
+      const app = makeResult.app
+      const server = makeResult.server
+      const asyncMutexScope = makeResult.asyncMutex
+      server.authTimestampCache = new MockAuthTimestampCache()
+
+      const sk = testPairs[1]
+      const fileContents = sk.toWIF()
+      const blob = Buffer.from(fileContents)
+
+      const address = ecPairToAddress(sk)
+
+      let response = await request(app)
+        .get('/hub_info/')
+        .expect(200)
+    
+      const challenge = JSON.parse(response.text).challenge_text
+      const authPart = auth.V1Authentication.makeAuthPart(sk, challenge)
+      const authorization = `bearer ${authPart}`
+
+      const passThrough1 = new PassThrough()
+      passThrough1.write("stuff", "utf8")
+
+      const resolves: Set<() => void> = new Set()
+      inMemoryDriver.onWriteMiddleware.add((args) => {
+        return new Promise(resolve => {
+          resolves.add(resolve)
+        })
+      })
+
+      const reqPromise1 = request(app).post(`/store/${address}/helloWorld`)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(202)
+
+      const reqPromise2 = request(app).post(`/store/${address}/helloWorld`)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(409)
+
+      const reqPromise3 = request(app).delete(`/delete/${address}/helloWorld`)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(409)
+
+      const releaseRequests = new Promise(resolve => {
+        setTimeout(() => {
+          for (const release of resolves) {
+            release()
+          }
+          resolve()
+        }, 50)
+      })
+
+      await Promise.all([reqPromise2, reqPromise1, reqPromise3, releaseRequests])
+
+      await reqPromise1
+      t.ok('First request (store) passes with no concurrent conflict')
+      await reqPromise2
+      t.ok('Second request (store) fails with concurrent conflict')
+      await reqPromise3
+      t.ok('Third request (delete) fails with concurrent conflict')
+
+      inMemoryDriver.onWriteMiddleware.clear()
+
+      await request(app).post(`/store/${address}/helloWorld`)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(202)
+
+      t.ok('Fourth request (store) passes with no concurrent conflict')
+
+      await request(app).delete(`/delete/${address}/helloWorld`)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .send(blob)
+        .expect(202)
+
+      t.ok('Fifth request (delete) passes with no concurrent conflict')
+
+      t.equals(asyncMutexScope.openedCount, 0, 'Should have no open mutexes when no requests are open')
+
+    } finally {
+      inMemoryDriver.dispose()
+    }
+  });
+
+
+
   test('handle request (InMemory driver)', async (t) => {
     const fetch = NodeFetch
     const inMemoryDriver = await InMemoryDriver.spawn()

--- a/reader/.eslintrc.js
+++ b/reader/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
     "new-cap": 0,
     "brace-style": 2,
     "semi": [2, "never"],
-    "valid-jsdoc": ["error"],
 
     "@typescript-eslint/indent": [2, 2, {
       "FunctionDeclaration": { "parameters": "first" },


### PR DESCRIPTION
## Goal of PR

Implement mutex around file http handlers that perform file mutations: `POST /store/address/file` and `DELETE /delete/address/file`.

## Implementation

A mutex is unique to a `address/file` endpoint. When an operation is in progress for a given resource, subsequence requests to the modify the resource are immediately rejected with an HTTP 409 Conflict. 

## Manual Testing

Instantiating many concurrent POST or DELETE requests to the same endpoint, using something like curl or a load tester. 

## Automated Testing

Tests implemented for full coverage of the mutex implementation and http conflict error paths. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
