### PR TITLE
Set the CORs preflight header to be cached for 24 hours

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or `/delete/${address}/...` endpoints are now always rejected with a 
   `HTTP 409 Conflict` error. Previously, this was undefined behavior
   that the back-end storage drivers dealt with in different ways. 
+- The `Access-Control-Max-Age` header for preflight CORs OPTION responses
+  set to 24 hours. 
 
 
 ## [2.5.3]

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -43,7 +43,8 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
   app.use(expressWinston.logger({
     winstonInstance: logger }))
 
-  app.use(cors())
+  // Set the Access-Control-Max-Age header to 24 hours.
+  app.use(cors({maxAge: 86400}))
 
   // sadly, express doesn't like to capture slashes.
   //  but that's okay! regexes solve that problem

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -135,6 +135,13 @@ export function testHttpWithInMemoryDriver() {
       const path = `/store/${address}/helloWorld`
       const listPath = `/list-files/${address}`
 
+      // test CORs response
+      let corsReq = await request(app).options(path)
+        .set('Access-Control-Request-Method', 'POST')
+        .set('Access-Control-Request-Headers', 'authorization,content-type')
+        .expect(204)
+        .expect('Access-Control-Max-Age', '86400')
+
       let response = await request(app)
         .get('/hub_info/')
         .expect(200)


### PR DESCRIPTION
https://github.com/blockstack/gaia/issues/254

## Goal of PR

Set the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) CORs header. This prevents browsers from making redundant round-trip OPTION requests for every POST to gaia. 

## Implementation

Set the CORs `Access-Control-Max-Age` header to 24 hours. 

## Manual Testing

\- 

## Automated Testing

CORs option response header test implemented. 

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
