### PR TITLE
Fix #266 - incorrect http error code on delete file BadPathError

### DIFF
--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -122,7 +122,7 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
         } else if (err instanceof errors.AuthTokenTimestampValidationError) {
           writeResponse(res, { message: err.message, error: err.name  }, 401)
         } else if (err instanceof errors.BadPathError) {
-          writeResponse(res, { message: err.message, error: err.name  }, 400)
+          writeResponse(res, { message: err.message, error: err.name  }, 403)
         } else if (err instanceof errors.DoesNotExist) {
           writeResponse(res, { message: err.message, error: err.name  }, 404)
         } else if (err instanceof errors.NotEnoughProofError) {

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -251,7 +251,7 @@ export function testHttpWithInMemoryDriver() {
       await request(app).delete(`/delete/${address}/../traversal`)
         .set('Authorization', authorization)
         .send()
-        .expect(400)
+        .expect(403)
 
       await request(app).delete(`/delete/${testAddrs[4]}/anyfile`)
         .set('Authorization', authorization)


### PR DESCRIPTION
## Goal of PR

Fix https://github.com/blockstack/gaia/issues/266


https://github.com/blockstack/gaia/blob/ef0771833cd56200e08e18631e62467f24e086af/hub/src/server/http.ts#L125

Minor bug with the delete file handler. Its `BadPathError` error returns a 400 and the others return a 403

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
