### PR TITLE
Change default `cache-control` setting

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for running an `https` server by providing the TLS/SSL certs. 
 - Support for running an `https` server with Automatic Certificate Management 
   Environment (ACME) via `Let's Encrypt (TM)`. 
+### Changed
+- Modify the default `cacheControl` setting from `public, max-age=1` to `no-cache`.
 
 ## [2.6.0]
 ### Added

--- a/hub/config-schema.json
+++ b/hub/config-schema.json
@@ -140,7 +140,7 @@
             "type": "string"
         },
         "cacheControl": {
-            "default": "public, max-age=1",
+            "default": "no-cache",
             "type": "string"
         },
         "diskSettings": {

--- a/hub/src/server/config.ts
+++ b/hub/src/server/config.ts
@@ -194,7 +194,7 @@ export class HubConfig {
    * @TJS-type integer
    */
   pageSize? = 100;
-  cacheControl? = 'public, max-age=1';
+  cacheControl? = 'no-cache';
   /**
    * The maximum allowed POST body size in megabytes. 
    * The content-size header is checked, and the POST body stream 


### PR DESCRIPTION
## Goal of PR

Closes https://github.com/blockstack/gaia/issues/273

Update the default `cacheControl` config setting to match the PBC hub.

For context see https://github.com/blockstack/blockstack.js/issues/732#issuecomment-544659629

## Implementation

Describe how that goal was achieved through the submitted implementation.

## Manual Testing

Setting performed and documented at https://github.com/blockstack/blockstack.js/issues/732#issuecomment-544659629

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
