### PR TITLE
Concurrency control

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,7 @@
             "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
             "env": {
                 "DRIVER_CONFIG_TEST_DATA": "${workspaceFolder}/hub/configs/drivers.json",
+                "TS_NODE_PROJECT": "${workspaceFolder}/hub/test/tsconfig.json"
             },
             "cwd": "${workspaceFolder}/hub",
             "outputCapture": "std"

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ interface DriverModel {
    * @param options.contentType - the HTTP content-type of the file
    * @param options.stream - the data to be stored at `path`
    * @param options.contentLength - the bytes of content in the stream
-   * @returns Promise that resolves to the public-readable URL of the stored content.
+   * @param options.ifMatch - optional etag value to be used for optimistic concurrency control
+   * @returns Promise that resolves to an object containing a public-readable URL of the stored content and the objects etag value
    */
   performWrite(options: { 
     path: string;

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ interface DriverModel {
    * @param options.stream - the data to be stored at `path`
    * @param options.contentLength - the bytes of content in the stream
    * @param options.ifMatch - optional etag value to be used for optimistic concurrency control
+   * @param options.ifNoneMatch - used with the `*` value to save a file not known to exist, 
+   * guaranteeing that another upload didn't happen before, losing the data of the previous
    * @returns Promise that resolves to an object containing a public-readable URL of the stored content and the objects etag value
    */
   performWrite(options: { 
@@ -287,6 +289,7 @@ interface DriverModel {
     contentLength: number;
     contentType: string;
     ifMatch?: string;
+    ifNoneMatch?: string;
   }): Promise<{
     publicURL: string,
     etag: string

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ On success, it returns a `202` status, and a JSON object:
 
 ```javascript
 {
- "publicUrl": "${read-url-prefix}/${address}/${path}"
+ "publicURL": "${read-url-prefix}/${address}/${path}"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,13 @@ the required CORS headers `Access-Control-Allow-Origin` and `Access-Control-Allo
 
 ---
 
+##### `HEAD ${read-url-prefix}/${address}/${path}`
+
+Returns the same headers as the corresponding `GET` request. `HEAD` requests
+do not return a response body. 
+
+---
+
 ##### `POST ${hubUrl}/store/${address}/${path}`
 
 This performs a write to the gaia hub at `${path}`. 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ On success, it returns a `202` status, and a JSON object:
 
 ```javascript
 {
- "publicURL": "${read-url-prefix}/${address}/${path}"
+ "publicURL": "${read-url-prefix}/${address}/${path}",
+ "etag": "version-identifier"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -385,10 +385,9 @@ The Gaia storage API defines the following endpoints:
 
 ##### `GET ${read-url-prefix}/${address}/${path}`
 
-This returns the data stored by the gaia hub at `${path}`. In order
-for this to be usable from web applications, this read path _must_
-set the appropriate CORS headers. The HTTP Content-Type of the file
-should match the Content-Type of the corresponding write.
+This returns the data stored by the gaia hub at `${path}`.
+The response headers include `Content-Type` and `ETag`, along with
+the required CORS headers `Access-Control-Allow-Origin` and `Access-Control-Allow-Methods`.
 
 ---
 
@@ -409,6 +408,22 @@ The `POST` must contain an authentication header with a bearer token.
 The bearer token's content and generation is described in
 the [access control](#address-based-access-control) section of this
 document.
+
+Additionally it must contain an `If-Match` header containing the most
+up to date ETag. This ETag is returned in the response body of the _store_
+`POST` request, the response headers of `GET` and `HEAD` requests, and in
+the returned entries in `list-files` request. If the file has been updated
+elsewhere and the ETag supplied in the `If-Match` header doesn't match that
+of the file in gaia, a `412 Precondition Failed` error will be returned. The
+JSON body of this error contains the expected, up-to-date ETag:
+
+```javascript
+{
+  "error": "PreconditionFailedError",
+  "expectedEtag": "the-up-to-date-etag",
+  "message": "error-message"
+}
+```
 
 Some backend storage drivers will return error `409 Conflict` when a 
 concurrent write to the same file path occurs. This can be handled with
@@ -481,8 +496,8 @@ If the post body contains a `stat: true` field then the returned JSON includes f
 ```jsonc
 {
   "entries": [
-    { "name": "string", "lastModifiedDate": "number", "contentLength": "number" },
-    { "name": "string", "lastModifiedDate": "number", "contentLength": "number" },
+    { "name": "string", "lastModifiedDate": "number", "contentLength": "number", "etag": "string" },
+    { "name": "string", "lastModifiedDate": "number", "contentLength": "number", "etag": "string" },
     // ...
   ],
   "page": "string" // possible pagination marker

--- a/README.md
+++ b/README.md
@@ -285,7 +285,11 @@ interface DriverModel {
     stream: Readable;
     contentLength: number;
     contentType: string;
-  }): Promise<string>;
+    ifMatch?: string;
+  }): Promise<{
+    publicURL: string,
+    etag: string
+  }>;
 
   /**
    * Deletes a file. Throws a `DoesNotExist` if the file does not exist. 
@@ -324,6 +328,7 @@ interface DriverModel {
     lastModifiedDate: number;
     contentLength: number;
     contentType: string;
+    etag: string;
   }>;
 
   /**
@@ -340,6 +345,7 @@ interface DriverModel {
     lastModifiedDate: number;
     contentLength: number;
     contentType: string;
+    etag: string;
   }>;
 
   /**
@@ -370,6 +376,7 @@ interface DriverModel {
         name: string;
         lastModifiedDate: number;
         contentLength: number;
+        etag: string;
     }[];
     page?: string;
   }>;

--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return ETag in response body of all requests.
 - Read ETag value from If-Match request header and conditionally approve
   write requests if the value is up to date for optimistic concurrency control.
+- Read the If-None-Match request header to conditionally approve a file overwrite.
 - New explicit error for requests that fail to provide an up to date ETag in
-  the If-Match header (412 Precondition Failed Error).
+  the If-Match header (412 Precondition Failed Error), or an `*` in the If-None-Match
+  header.
 ### Changed
 - Updated DriverModel's WriteResult type to include ETag.
 

--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0]
+### Added
+- Return ETag in response body of all requests.
+- Read ETag value from If-Match request header and conditionally approve
+  write requests if the value is up to date for optimistic concurrency control.
+- New explicit error for requests that fail to provide an up to date ETag in
+  the If-Match header (412 Precondition Failed Error).
+### Changed
+- Updated DriverModel's WriteResult type to include ETag.
+
 ## [2.7.0]
 ### Added
 - Support for running an `https` server by providing the TLS/SSL certs. 

--- a/hub/README.md
+++ b/hub/README.md
@@ -47,7 +47,7 @@ In order for a Gaia hub to operate properly CORS must be configured.
 For the **write endpoint**, you must configure your server to include the following headers:
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE`
-- `Access-Control-Allow-Headers: Authorization, If-Match`
+- `Access-Control-Allow-Headers: Authorization, Content-Type, If-Match`
 
 
 For the **read endpoint**, you must configure your storage driver to include the following headers:

--- a/hub/README.md
+++ b/hub/README.md
@@ -44,15 +44,15 @@ These driver may require you to provide additional credentials for performing wr
 
 In order for a Gaia hub to operate properly CORS must be configured.
 
-For the **write endpoint**, you must configure your server to include the following headers:
+For the **write endpoint**, you must configure your server to respond to [CORS requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). The minimum required HTTP response headers must include:
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE`
 - `Access-Control-Allow-Headers: Authorization, Content-Type, If-Match`
 
 
 For the **read endpoint**, you must configure your storage driver to include the following headers:
-- `Access-Control-Allow-Methods: GET`
 - `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, HEAD`
 - `Access-Control-Expose-Headers: ETag`
 
 Here's an example of a storage driver (S3) configuration:

--- a/hub/README.md
+++ b/hub/README.md
@@ -47,7 +47,7 @@ In order for a Gaia hub to operate properly CORS must be configured.
 For the **write endpoint**, you must configure your server to respond to [CORS requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). The minimum required HTTP response headers must include:
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE`
-- `Access-Control-Allow-Headers: Authorization, Content-Type, If-Match`
+- `Access-Control-Allow-Headers: Authorization, Content-Type, If-Match, If-None-Match`
 
 
 For the **read endpoint**, you must configure your storage driver to include the following headers:

--- a/hub/README.md
+++ b/hub/README.md
@@ -40,6 +40,35 @@ These driver may require you to provide additional credentials for performing wr
 
 *Note:* The disk driver requires a *nix like filesystem interface, and will not work correctly when trying to run in a Windows environment.
 
+### CORS Configuration
+
+In order for a Gaia hub to operate properly CORS must be configured.
+
+For the **write endpoint**, you must configure your server to include the following headers:
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE`
+- `Access-Control-Allow-Headers: Authorization, If-Match`
+
+
+For the **read endpoint**, you must configure your storage driver to include the following headers:
+- `Access-Control-Allow-Methods: GET`
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Expose-Headers: ETag`
+
+Here's an example of a storage driver (S3) configuration:
+
+```xml
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <CORSRule>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedOrigin>*</AllowedOrigin>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>0</MaxAgeSeconds>
+  </CORSRule>
+</CORSConfiguration>
+```
+
 ### Require Correct Hub URL
 
 If you turn on the `requireCorrectHubUrl` option in your `config.json`

--- a/hub/package.json
+++ b/hub/package.json
@@ -69,7 +69,7 @@
     "lint": "eslint --ext .ts ./src -f unix",
     "lint:fix": "eslint --ext .ts ./src --fix",
     "test:build": "tsc -p ./test/tsconfig.json",
-    "test:coverage": "cross-env NODE_ENV=test nyc node ./test/src/index.ts",
+    "test:coverage": "cross-env NODE_ENV=test LOCAL_DRIVER_CONFIG_TEST_DATA=configs/drivers.json nyc node ./test/src/index.ts",
     "test": "npm-run-all build --parallel lint test:coverage"
   },
   "repository": {

--- a/hub/src/server/driverModel.ts
+++ b/hub/src/server/driverModel.ts
@@ -70,6 +70,8 @@ export interface PerformRenameArgs {
 }
 
 export interface DriverModel {
+  supportsETagMatching: boolean;
+
   getReadURLPrefix(): string;
   performWrite(args: PerformWriteArgs): Promise<WriteResult>;
   performDelete(args: PerformDeleteArgs): Promise<void>;

--- a/hub/src/server/driverModel.ts
+++ b/hub/src/server/driverModel.ts
@@ -30,6 +30,11 @@ export interface PerformWriteArgs {
   contentType: string;
 }
 
+export interface WriteResult {
+  publicURL: string;
+  etag: string;
+}
+
 export interface PerformDeleteArgs {
   path: string;
   storageTopLevel: string;
@@ -53,6 +58,7 @@ export interface PerformStatArgs {
 export interface StatResult {
   exists: boolean;
   lastModifiedDate: number;
+  etag: string;
   contentLength: number;
   contentType: string;
 }
@@ -65,7 +71,7 @@ export interface PerformRenameArgs {
 
 export interface DriverModel {
   getReadURLPrefix(): string;
-  performWrite(args: PerformWriteArgs): Promise<string>;
+  performWrite(args: PerformWriteArgs): Promise<WriteResult>;
   performDelete(args: PerformDeleteArgs): Promise<void>;
   performRename(args: PerformRenameArgs): Promise<void>;
   performStat(args: PerformStatArgs): Promise<StatResult>;

--- a/hub/src/server/driverModel.ts
+++ b/hub/src/server/driverModel.ts
@@ -28,6 +28,7 @@ export interface PerformWriteArgs {
   stream: Readable;
   contentLength: number;
   contentType: string;
+  ifMatch?: string;
 }
 
 export interface WriteResult {

--- a/hub/src/server/driverModel.ts
+++ b/hub/src/server/driverModel.ts
@@ -29,6 +29,7 @@ export interface PerformWriteArgs {
   contentLength: number;
   contentType: string;
   ifMatch?: string;
+  ifNoneMatch?: string;
 }
 
 export interface WriteResult {

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -194,7 +194,8 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
         blobCacheControl: this.cacheControl || undefined
       },
       modifiedAccessConditions: {
-        ifMatch: args.ifMatch
+        ifMatch: args.ifMatch,
+        ifNoneMatch: args.ifNoneMatch
       }
     }
 

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -10,6 +10,7 @@ import {
 } from '../driverModel'
 import { Readable } from 'stream'
 import { BlobGetPropertiesHeaders, BlobProperties } from '@azure/storage-blob/typings/src/generated/src/models'
+import { IUploadStreamToBlockBlobOptions } from '@azure/storage-blob'
 
 export interface AZ_CONFIG_TYPE {
   azCredentials: {
@@ -188,14 +189,16 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     */
     const maxBuffers = 1
 
-    const options = {
+    const options: IUploadStreamToBlockBlobOptions = {
       blobHTTPHeaders: {
         blobContentType: args.contentType,
         blobCacheControl: this.cacheControl || undefined
       },
-      modifiedAccessConditions: {
-        ifMatch: args.ifMatch,
-        ifNoneMatch: args.ifNoneMatch
+      accessConditions: {
+        modifiedAccessConditions: {
+          ifMatch: args.ifMatch,
+          ifNoneMatch: args.ifNoneMatch
+        }
       }
     }
 

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -10,7 +10,6 @@ import {
 } from '../driverModel'
 import { Readable } from 'stream'
 import { BlobGetPropertiesHeaders, BlobProperties } from '@azure/storage-blob/typings/src/generated/src/models'
-import { IUploadStreamToBlockBlobOptions } from '@azure/storage-blob'
 
 export interface AZ_CONFIG_TYPE {
   azCredentials: {
@@ -189,7 +188,7 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     */
     const maxBuffers = 1
 
-    const options: IUploadStreamToBlockBlobOptions = {
+    const options: azure.IUploadStreamToBlockBlobOptions = {
       blobHTTPHeaders: {
         blobContentType: args.contentType,
         blobCacheControl: this.cacheControl || undefined

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -32,7 +32,7 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
   cacheControl?: string
   initPromise: Promise<void>
 
-  supportsETagMatching = false;
+  supportsETagMatching = true;
 
   static getConfigInformation() {
     const envVars: any = {}
@@ -188,15 +188,19 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     */
     const maxBuffers = 1
 
+    let options = {
+      blobHTTPHeaders: {
+        blobContentType: args.contentType,
+        blobCacheControl: this.cacheControl || undefined
+      },
+      modifiedAccessConditions: {
+        ifMatch: args.ifMatch
+      }
+    }
+
     try {
       const uploadResult = await azure.uploadStreamToBlockBlob(
-        azure.Aborter.none, args.stream,
-        blockBlobURL, bufferSize, maxBuffers, {
-          blobHTTPHeaders: {
-            blobContentType: args.contentType,
-            blobCacheControl: this.cacheControl || undefined
-          }
-        }
+        azure.Aborter.none, args.stream, blockBlobURL, bufferSize, maxBuffers, options
       )
 
       // Return success and url to user

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -32,6 +32,8 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
   cacheControl?: string
   initPromise: Promise<void>
 
+  supportsETagMatching = false;
+
   static getConfigInformation() {
     const envVars: any = {}
     const azCredentials: any = {}

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -188,7 +188,7 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     */
     const maxBuffers = 1
 
-    let options = {
+    const options = {
       blobHTTPHeaders: {
         blobContentType: args.contentType,
         blobCacheControl: this.cacheControl || undefined

--- a/hub/src/server/drivers/GcDriver.ts
+++ b/hub/src/server/drivers/GcDriver.ts
@@ -220,10 +220,9 @@ class GcDriver implements DriverModel, DriverModelTestMethods {
       await pipelineAsync(args.stream, fileWriteStream)
       logger.debug(`storing ${filename} in bucket ${this.bucket}`)
 
-      return {
-        publicURL,
-        etag: fileDestination.metadata.etag
-      }
+      const etag = Buffer.from(fileDestination.metadata.md5Hash, 'base64').toString('hex')
+
+      return { publicURL, etag }
     } catch (error) {
       logger.error(`failed to store ${filename} in bucket ${this.bucket}`)
       throw new Error('Google cloud storage failure: failed to store' +

--- a/hub/src/server/drivers/GcDriver.ts
+++ b/hub/src/server/drivers/GcDriver.ts
@@ -257,7 +257,7 @@ class GcDriver implements DriverModel, DriverModelTestMethods {
     const lastModified = dateToUnixTimeSeconds(new Date(metadata.updated))
     const result: StatResult = {
       exists: true,
-      etag: metadata.etag,
+      etag: Buffer.from(metadata.md5Hash, 'base64').toString('hex'),
       contentType: metadata.contentType,
       contentLength: parseInt(metadata.size),
       lastModifiedDate: lastModified

--- a/hub/src/server/drivers/GcDriver.ts
+++ b/hub/src/server/drivers/GcDriver.ts
@@ -32,6 +32,8 @@ class GcDriver implements DriverModel, DriverModelTestMethods {
   initPromise: Promise<void>
   resumable: boolean
 
+  supportsETagMatching = false;
+
   static getConfigInformation() {
     const envVars: any = {}
     const gcCredentials: any = {}

--- a/hub/src/server/drivers/S3Driver.ts
+++ b/hub/src/server/drivers/S3Driver.ts
@@ -2,9 +2,9 @@ import * as S3 from 'aws-sdk/clients/s3'
 
 import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
 import { 
-  ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, PerformStatArgs, 
-  StatResult, PerformReadArgs, ReadResult, PerformListFilesArgs, ListFilesStatResult, 
-  ListFileStatResult, DriverStatics, DriverModel, DriverModelTestMethods 
+  ListFilesResult, PerformWriteArgs, WriteResult, PerformDeleteArgs, PerformRenameArgs,
+  PerformStatArgs, StatResult, PerformReadArgs, ReadResult, PerformListFilesArgs,
+  ListFilesStatResult, ListFileStatResult, DriverStatics, DriverModel, DriverModelTestMethods 
 } from '../driverModel'
 import { timeout, logger, dateToUnixTimeSeconds } from '../utils'
 
@@ -179,7 +179,7 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
     return listResult
   }
 
-  async performWrite(args: PerformWriteArgs): Promise<string> {
+  async performWrite(args: PerformWriteArgs): Promise<WriteResult> {
     if (args.contentType && args.contentType.length > 1024) {
       throw new InvalidInputError('Invalid content-type')
     }
@@ -200,16 +200,20 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
 
     // Upload stream to s3
     try {
-      await this.s3.upload(s3params).promise()
+      const uploadResult = await this.s3.upload(s3params).promise()
+
+      const publicURL = `${this.getReadURLPrefix()}${s3key}`
+      logger.debug(`storing ${s3key} in bucket ${this.bucket}`)
+
+      return {
+        publicURL,
+        etag: uploadResult.ETag
+      }
     } catch (error) {
       logger.error(`failed to store ${s3key} in bucket ${this.bucket}`)
       throw new Error('S3 storage failure: failed to store' +
         ` ${s3key} in bucket ${this.bucket}: ${error}`)
     }
-
-    const publicURL = `${this.getReadURLPrefix()}${s3key}`
-    logger.debug(`storing ${s3key} in bucket ${this.bucket}`)
-    return publicURL
   }
 
   async performDelete(args: PerformDeleteArgs): Promise<void> {
@@ -280,6 +284,7 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
     const result: StatResult = {
       exists: true,
       lastModifiedDate: lastModified,
+      etag: obj.ETag,
       contentLength: (obj as S3.HeadObjectOutput).ContentLength || (obj as S3.Object).Size,
       contentType: (obj as S3.HeadObjectOutput).ContentType
     }

--- a/hub/src/server/drivers/S3Driver.ts
+++ b/hub/src/server/drivers/S3Driver.ts
@@ -28,6 +28,8 @@ class S3Driver implements DriverModel, DriverModelTestMethods {
   cacheControl?: string
   initPromise: Promise<void>
 
+  supportsETagMatching = false;
+
   static getConfigInformation() {
     const envVars: any = {}
     const awsCredentials: any = {}

--- a/hub/src/server/drivers/diskDriver.ts
+++ b/hub/src/server/drivers/diskDriver.ts
@@ -26,6 +26,8 @@ class DiskDriver implements DriverModel {
   pageSize: number
   initPromise: Promise<void>
 
+  supportsETagMatching = false;
+
   static getConfigInformation() {
     const envVars: any = {}
     if (process.env['GAIA_DISK_STORAGE_ROOT_DIR']) {

--- a/hub/src/server/drivers/diskDriver.ts
+++ b/hub/src/server/drivers/diskDriver.ts
@@ -1,11 +1,13 @@
 import * as fs from 'fs-extra'
 import { readdir } from 'fs'
+import { PassThrough } from 'stream'
 import { BadPathError, InvalidInputError, DoesNotExist } from '../errors'
 import * as Path from 'path'
+import * as crypto from 'crypto'
 import { 
-  ListFilesResult, PerformWriteArgs, PerformDeleteArgs, PerformRenameArgs, PerformStatArgs, 
-  StatResult, PerformReadArgs, ReadResult, PerformListFilesArgs, ListFilesStatResult, 
-  ListFileStatResult, DriverStatics, DriverModel 
+  ListFilesResult, PerformWriteArgs, WriteResult, PerformDeleteArgs, PerformRenameArgs,
+  PerformStatArgs, StatResult, PerformReadArgs, ReadResult, PerformListFilesArgs,
+  ListFilesStatResult, ListFileStatResult, DriverStatics, DriverModel 
 } from '../driverModel'
 import { pipelineAsync, logger, dateToUnixTimeSeconds } from '../utils'
 
@@ -213,13 +215,13 @@ class DiskDriver implements DriverModel {
 
     // remember content type in $storageRootDir/.gaia-metadata/$address/$path
     // (i.e. these files are outside the address bucket, and are thus hidden)
-    const contentTypePath = Path.join(
+    const metaDataFilePath = Path.join(
       this.storageRootDirectory, METADATA_DIRNAME, args.storageTopLevel, args.path)
 
-    return { absoluteFilePath: abspath, contentTypeFilePath: contentTypePath }
+    return { absoluteFilePath: abspath, metaDataFilePath }
   }
 
-  async performWrite(args: PerformWriteArgs): Promise<string> {
+  async performWrite(args: PerformWriteArgs): Promise<WriteResult> {
 
     const contentType = args.contentType
 
@@ -228,27 +230,45 @@ class DiskDriver implements DriverModel {
       throw new InvalidInputError('Invalid content-type')
     }
 
-    const { absoluteFilePath, contentTypeFilePath } = this.getFullFilePathInfo(args)
+    const { absoluteFilePath, metaDataFilePath } = this.getFullFilePathInfo(args)
 
     const absdirname = Path.dirname(absoluteFilePath)
     await this.mkdirs(absdirname)
 
+    const hash = crypto.createHash('md5')
+    const hashMonitoredStream = new PassThrough({
+      transform: (chunk: Buffer, _encoding, callback) => {
+        hash.update(chunk)
+        // Pass the chunk Buffer through, untouched. This takes the fast 
+        // path through the stream pipe lib. 
+        callback(null, chunk)
+      }
+    })
+
+    const hashMonitorPipeline = pipelineAsync(args.stream, hashMonitoredStream)
+
     const writePipe = fs.createWriteStream(absoluteFilePath, { mode: 0o600, flags: 'w' })
-    await pipelineAsync(args.stream, writePipe)
+    const fileStreamPipeline = pipelineAsync(hashMonitoredStream, writePipe)
 
+    await Promise.all([hashMonitorPipeline, fileStreamPipeline])
 
-    const contentTypeDirPath = Path.dirname(contentTypeFilePath)
-    await this.mkdirs(contentTypeDirPath)
+    const etag = hash.digest('hex')
+
+    const metaDataDirPath = Path.dirname(metaDataFilePath)
+    await this.mkdirs(metaDataDirPath)
     await fs.writeFile(
-      contentTypeFilePath, 
-      JSON.stringify({ 'content-type': contentType }), { mode: 0o600 })
+      metaDataFilePath, 
+      JSON.stringify({ 'content-type': contentType, etag }), { mode: 0o600 })
 
-    return `${this.readURL}${args.storageTopLevel}/${args.path}`
+    return {
+      publicURL: `${this.readURL}${args.storageTopLevel}/${args.path}`,
+      etag
+    }
     
   }
 
   async performDelete(args: PerformDeleteArgs): Promise<void> {
-    const { absoluteFilePath, contentTypeFilePath } = this.getFullFilePathInfo(args)
+    const { absoluteFilePath, metaDataFilePath } = this.getFullFilePathInfo(args)
     let stat: fs.Stats
     try {
       stat = await fs.stat(absoluteFilePath)
@@ -267,24 +287,28 @@ class DiskDriver implements DriverModel {
       throw new DoesNotExist('Path is not a file')
     }
     await fs.unlink(absoluteFilePath)
-    await fs.unlink(contentTypeFilePath)
+    await fs.unlink(metaDataFilePath)
   }
 
-  static async parseFileStat(stat: fs.Stats, contentTypeFilePath: string): Promise<StatResult> {
-    const contentTypeJsonStr = await fs.readFile(contentTypeFilePath, 'utf8')
-    const contentType = JSON.parse(contentTypeJsonStr)['content-type']
+  static async parseFileStat(stat: fs.Stats, metaDataFilePath: string): Promise<StatResult> {
+    const metaDataJsonStr = await fs.readFile(metaDataFilePath, 'utf8')
+    const metaDataJson = JSON.parse(metaDataJsonStr)
+    const contentType = metaDataJson['content-type']
+    const etag = metaDataJson['etag']
     const lastModified = dateToUnixTimeSeconds(stat.mtime)
+
     const result: StatResult = {
       exists: true,
+      etag,
       contentLength: stat.size,
-      contentType: contentType,
+      contentType,
       lastModifiedDate: lastModified
     }
     return result
   }
 
   async performRead(args: PerformReadArgs): Promise<ReadResult> {
-    const { absoluteFilePath, contentTypeFilePath } = this.getFullFilePathInfo(args)
+    const { absoluteFilePath, metaDataFilePath } = this.getFullFilePathInfo(args)
     let stat: fs.Stats
     try {
       stat = await fs.stat(absoluteFilePath)
@@ -302,7 +326,7 @@ class DiskDriver implements DriverModel {
       // (pseudo-directory) of existing blobs.
       throw new DoesNotExist('File does not exist')
     }
-    const fileStat = await DiskDriver.parseFileStat(stat, contentTypeFilePath)
+    const fileStat = await DiskDriver.parseFileStat(stat, metaDataFilePath)
     const dataStream = fs.createReadStream(absoluteFilePath)
     const result: ReadResult = {
       ...fileStat,
@@ -313,7 +337,7 @@ class DiskDriver implements DriverModel {
   }
 
   async performStat(args: PerformStatArgs): Promise<StatResult> {
-    const { absoluteFilePath, contentTypeFilePath } = this.getFullFilePathInfo(args)
+    const { absoluteFilePath, metaDataFilePath } = this.getFullFilePathInfo(args)
     let stat: fs.Stats
     try {
       stat = await fs.stat(absoluteFilePath)
@@ -337,7 +361,7 @@ class DiskDriver implements DriverModel {
       } as StatResult
       return result
     }
-    const result = await DiskDriver.parseFileStat(stat, contentTypeFilePath)
+    const result = await DiskDriver.parseFileStat(stat, metaDataFilePath)
     return result
   }
 
@@ -375,7 +399,7 @@ class DiskDriver implements DriverModel {
     }
 
     await fs.move(pathsOrig.absoluteFilePath, pathsNew.absoluteFilePath, {overwrite: true})
-    await fs.move(pathsOrig.contentTypeFilePath, pathsNew.contentTypeFilePath, {overwrite: true})
+    await fs.move(pathsOrig.metaDataFilePath, pathsNew.metaDataFilePath, {overwrite: true})
   }
 
 }

--- a/hub/src/server/errors.ts
+++ b/hub/src/server/errors.ts
@@ -9,10 +9,9 @@ export class ValidationError extends Error {
 
 export class PreconditionFailedError extends Error {
   expectedEtag: string;
-  constructor (message: string, etag: string) {
+  constructor (message: string) {
     super(message)
     this.name = this.constructor.name
-    this.expectedEtag = etag
   }
 }
 

--- a/hub/src/server/errors.ts
+++ b/hub/src/server/errors.ts
@@ -7,6 +7,15 @@ export class ValidationError extends Error {
   }
 }
 
+export class PreconditionFailedError extends Error {
+  expectedEtag: string;
+  constructor (message: string, etag: string) {
+    super(message)
+    this.name = this.constructor.name
+    this.expectedEtag = etag
+  }
+}
+
 export class AuthTokenTimestampValidationError extends Error {
   oldestValidTokenTimestamp: number;
   constructor (message: string, oldestValidTokenTimestamp: number) {

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -48,9 +48,9 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
     // Set the Access-Control-Max-Age header to 24 hours.
     maxAge: 86400, 
     methods: 'DELETE,POST,GET,OPTIONS,HEAD',
-    // Allow the client to include If-Match header in http requests
+    // Allow the client to include match headers in http requests
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
-    allowedHeaders: 'Authorization,Content-Type,If-Match'
+    allowedHeaders: 'Authorization,Content-Type,If-Match,If-None-Match'
   })
   
   app.use(corsConfig)

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -43,8 +43,21 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
   app.use(expressWinston.logger({
     winstonInstance: logger }))
 
-  // Set the Access-Control-Max-Age header to 24 hours.
-  app.use(cors({maxAge: 86400}))
+  const corsConfig = cors({
+    origin: '*',
+    // Set the Access-Control-Max-Age header to 24 hours.
+    maxAge: 86400, 
+    methods: 'DELETE,POST,GET,OPTIONS,HEAD',
+    // Allow the client to include If-Match header in http requests
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+    allowedHeaders: 'Authorization,Content-Type,If-Match'
+  })
+  
+  app.use(corsConfig)
+
+  // Enabling CORS Pre-Flight
+  // https://www.npmjs.com/package/cors#enabling-cors-pre-flight
+  app.options('*', corsConfig)
 
   // sadly, express doesn't like to capture slashes.
   //  but that's okay! regexes solve that problem

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -61,8 +61,8 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
 
     const handleRequest = async () => {
       try {
-        const publicURL = await server.handleRequest(address, filename, req.headers, req)
-        writeResponse(res, { publicURL }, 202)
+        const responseData = await server.handleRequest(address, filename, req.headers, req)
+        writeResponse(res, responseData, 202)
       } catch (err) {
         logger.error(err)
         if (err instanceof errors.ValidationError) {
@@ -77,6 +77,8 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
           writeResponse(res, { message: err.message, error: err.name }, 409) 
         } else if (err instanceof errors.PayloadTooLargeError) {
           writeResponse(res, { message: err.message, error: err.name }, 413)
+        } else if (err instanceof errors.PreconditionFailedError) {
+          writeResponse(res, { message: err.message, error: err.name, etag: err.expectedEtag }, 412)
         } else {
           writeResponse(res, { message: 'Server Error' }, 500)
         }

--- a/hub/src/server/server.ts
+++ b/hub/src/server/server.ts
@@ -223,6 +223,12 @@ export class HubServer {
       throw new PreconditionFailedError('Request should not contain both if-match and if-none-match headers')
     }
 
+    // only support using if-none-match for file creation, values that aren't the wildcard are prohibited
+    if (ifNoneMatchTag && ifNoneMatchTag !== '*') {
+      throw new PreconditionFailedError('Misuse of the if-none-match header. Expected to be * on write requests.')
+    }
+
+    // handle etag matching if not supported at the driver level
     if (!this.driver.supportsETagMatching) {
       // allow overwrites if tag is wildcard 
       if (ifMatchTag && ifMatchTag !== '*') {
@@ -246,8 +252,6 @@ export class HubServer {
         if (statResult.exists) {
           throw new PreconditionFailedError('The entity you are trying to create already exists')
         }
-      } else if (ifNoneMatchTag && ifNoneMatchTag !== '*') {
-        throw new PreconditionFailedError('Misuse of the if-none-match header. Expected to be * on write requests.')
       }
     }
 

--- a/hub/src/server/server.ts
+++ b/hub/src/server/server.ts
@@ -181,6 +181,7 @@ export class HubServer {
       'content-type'?: string,
       'content-length'?: string | number,
       'if-match'?: string,
+      'if-none-match'?: string,
       authorization?: string
     },
     stream: Readable

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -73,7 +73,8 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       t.equal(resptxt, sampleDataString, `Must get back ${sampleDataString}: got back: ${resptxt}`)
       if (!mockTest) {
         t.equal(resp.headers.get('content-type'), 'application/octet-stream', 'Read endpoint response should contain correct content-type')
-        t.equal(resp.headers.get('etag').replace(/^"|"$/g, '') === writeResponse.etag.replace(/^"|"$/g, ''), true)
+        t.equal(resp.headers.get('etag').replace(/^"|"$/g, '') === writeResponse.etag.replace(/^"|"$/g, ''), true,
+          'Read endpoint should contain correct etag')
         t.equal(resp.headers.get('cache-control'), cacheControlOpt, 'cacheControl not respected in response headers')
       }
 

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -168,7 +168,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           const stream = new PassThrough()
           stream.end('Hello read test!')
           const dateNow1 = Math.round(Date.now() / 1000)
-          await driver.performWrite({
+          const writeResult = await driver.performWrite({
             path: readTestFile,
             storageTopLevel: topLevelStorage,
             stream: stream,
@@ -185,6 +185,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           t.equal(readResult.exists, true, 'File stat should return exists after write')
           t.equal(readResult.contentLength, 16, 'File stat should have correct content length')
           t.equal(readResult.contentType, "text/plain; charset=utf-8", 'File stat should have correct content type')
+          t.equal(readResult.etag, writeResult.etag, 'File read should return same etag as write result')
           const dateDiff = Math.abs(readResult.lastModifiedDate - dateNow1)
           t.equal(dateDiff < 10, true, `File stat last modified date is not within range, diff: ${dateDiff} -- ${readResult.lastModifiedDate} vs ${dateNow1}`)
 
@@ -239,7 +240,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           const stream1 = new PassThrough()
           stream1.end('abc sample content 1', 'utf8')
           const dateNow1 = Math.round(Date.now() / 1000)
-          await driver.performWrite({
+          const writeResult = await driver.performWrite({
             path: statTestFile,
             storageTopLevel: topLevelStorage,
             stream: stream1,
@@ -252,6 +253,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           const statResult = listStatResult.entries.find(e => e.name.includes(statTestFile))
           t.equal(statResult.exists, true, 'File stat should return exists after write')
           t.equal(statResult.contentLength, 20, 'File stat should have correct content length')
+          t.equal(statResult.etag, writeResult.etag, 'File read should return same etag as write file result')
           const dateDiff = Math.abs(statResult.lastModifiedDate - dateNow1)
           t.equal(dateDiff < 10, true, `File stat last modified date is not within range, diff: ${dateDiff} -- ${statResult.lastModifiedDate} vs ${dateNow1}`)
         } catch (error) {
@@ -264,7 +266,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           const stream1 = new PassThrough()
           stream1.end('abc sample content 1', 'utf8')
           const dateNow1 = Math.round(Date.now() / 1000)
-          await driver.performWrite({
+          const writeResult = await driver.performWrite({
             path: statTestFile,
             storageTopLevel: topLevelStorage,
             stream: stream1,
@@ -279,6 +281,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           t.equal(statResult.exists, true, 'File stat should return exists after write')
           t.equal(statResult.contentLength, 20, 'File stat should have correct content length')
           t.equal(statResult.contentType, "text/plain; charset=utf-8", 'File stat should have correct content type')
+          t.equal(statResult.etag, writeResult.etag, 'File stat should return same etag as write file result')
           const dateDiff = Math.abs(statResult.lastModifiedDate - dateNow1)
           t.equal(dateDiff < 10, true, `File stat last modified date is not within range, diff: ${dateDiff} -- ${statResult.lastModifiedDate} vs ${dateNow1}`)
         } catch (error) {

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -100,7 +100,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       }
 
       // if-match & if-none-match tests
-      if (!mockTest) {
+      if (!mockTest && driver.supportsETagMatching) {
         try {
           sampleData = getSampleData();
           await driver.performWrite({

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -73,7 +73,7 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       t.equal(resptxt, sampleDataString, `Must get back ${sampleDataString}: got back: ${resptxt}`)
       if (!mockTest) {
         t.equal(resp.headers.get('content-type'), 'application/octet-stream', 'Read endpoint response should contain correct content-type')
-        t.equal(resp.headers.get('etag').replace(/^"|"$/g, '') === writeResponse.etag.replace(/^"|"$/g, ''), true,
+        t.equal(resp.headers.get('etag'), writeResponse.etag,
           'Read endpoint should contain correct etag')
         t.equal(resp.headers.get('cache-control'), cacheControlOpt, 'cacheControl not respected in response headers')
       }

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -53,13 +53,14 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       // Test binary data content-type
       const binFileName = `${fileSubDir}/foo.bin`;
       let sampleData = getSampleData();
-      let readUrl = await driver.performWrite({
+      let writeResponse = await driver.performWrite({
         path: binFileName,
         storageTopLevel: topLevelStorage,
         stream: sampleData.stream,
         contentType: 'application/octet-stream',
         contentLength: sampleData.contentLength
       });
+      let readUrl = writeResponse.publicURL;
       t.ok(readUrl.startsWith(`${prefix}${topLevelStorage}`), `${readUrl} must start with readUrlPrefix ${prefix}${topLevelStorage}`)
 
       if (mockTest) {
@@ -71,7 +72,8 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       let resptxt = await resp.text()
       t.equal(resptxt, sampleDataString, `Must get back ${sampleDataString}: got back: ${resptxt}`)
       if (!mockTest) {
-        t.equal(resp.headers.get('content-type'), 'application/octet-stream', 'Read-end point response should contain correct content-type')
+        t.equal(resp.headers.get('content-type'), 'application/octet-stream', 'Read endpoint response should contain correct content-type')
+        t.equal(resp.headers.get('etag').replace(/^"|"$/g, '') === writeResponse.etag.replace(/^"|"$/g, ''), true)
         t.equal(resp.headers.get('cache-control'), cacheControlOpt, 'cacheControl not respected in response headers')
       }
 
@@ -83,12 +85,13 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
       // Test a text content-type that has implicit charset set
       const txtFileName = `${fileSubDir}/foo_text.txt`;
       sampleData = getSampleData();
-      readUrl = await driver.performWrite(
+      writeResponse = await driver.performWrite(
           { path: txtFileName,
             storageTopLevel: topLevelStorage,
             stream: sampleData.stream,
             contentType: 'text/plain; charset=utf-8',
             contentLength: sampleData.contentLength })
+      readUrl = writeResponse.publicURL;
       t.ok(readUrl.startsWith(`${prefix}${topLevelStorage}`), `${readUrl} must start with readUrlPrefix ${prefix}${topLevelStorage}`)
       if (mockTest) {
         addMockFetches(fetch, prefix, dataMap)
@@ -512,7 +515,8 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
           stream1.end()
           await utils.timeout(10)
           stream2.end()
-          const [ readEndpoint ] = await Promise.all([writeRequest1, writeRequest2])
+          const [ writeResponse ] = await Promise.all([writeRequest1, writeRequest2])
+          const readEndpoint = writeResponse.publicURL
           resp = await fetch(readEndpoint)
           resptxt = await resp.text()
           if (resptxt === 'xyz sample content 2' || resptxt === 'abc sample content 1') {

--- a/hub/test/src/testDrivers/InMemoryDriver.ts
+++ b/hub/test/src/testDrivers/InMemoryDriver.ts
@@ -22,6 +22,8 @@ export class InMemoryDriver implements DriverModel {
 
   onWriteMiddleware: Set<((arg: PerformWriteArgs) => Promise<void>)> = new Set()
 
+  supportsETagMatching = false;
+
   constructor(config: any) {
     this.pageSize = (config && config.pageSize) ? config.pageSize : 100
     this.files = new Map()

--- a/hub/test/src/testDrivers/InMemoryDriver.ts
+++ b/hub/test/src/testDrivers/InMemoryDriver.ts
@@ -35,7 +35,9 @@ export class InMemoryDriver implements DriverModel {
         res.set({
           'Content-Type': matchingFile.contentType,
           'ETag': matchingFile.etag,
-          'Cache-Control': (config || {}).cacheControl
+          'Cache-Control': (config || {}).cacheControl,
+          'Content-Length': matchingFile.content.byteLength,
+          'Last-Modified': matchingFile.lastModified.toUTCString()
         }).send(matchingFile.content)
       } else {
         res.status(404).send('Could not return file')

--- a/hub/test/src/testDrivers/integrationTestDrivers.ts
+++ b/hub/test/src/testDrivers/integrationTestDrivers.ts
@@ -19,7 +19,7 @@ import * as gaiaReader from '../../../../reader/src/http'
  *  - json string
  *  - base64 encoded json string
  */
-const driverConfigTestData = process.env.DRIVER_CONFIG_TEST_DATA
+const driverConfigTestData = process.env.DRIVER_CONFIG_TEST_DATA || process.env.LOCAL_DRIVER_CONFIG_TEST_DATA
 
 const envConfigPaths = { 
   az: process.env.AZ_CONFIG_PATH, 
@@ -39,7 +39,12 @@ if (driverConfigTestData) {
     let jsonStr;
     if (driverConfigTestData.endsWith('.json')) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as json file for driver config')
-        jsonStr = fs.readFileSync(driverConfigTestData, {encoding: 'utf8'})
+        if (!fs.existsSync(driverConfigTestData)) {
+          console.error(`File not found: ${path.resolve(driverConfigTestData)}`)
+          console.error(`Cannot load storage driver credentials file, integration tests will not run`)
+        } else {
+          jsonStr = fs.readFileSync(driverConfigTestData, {encoding: 'utf8'})
+        }
     } else if (/^\s*{/.test(driverConfigTestData)) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as json blob for driver config')
         jsonStr = driverConfigTestData
@@ -47,7 +52,10 @@ if (driverConfigTestData) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as b64 encoded json blob for driver config')
         jsonStr = new Buffer(driverConfigTestData, 'base64').toString('utf8')
     }
-    Object.assign(driverConfigs, JSON.parse(jsonStr))
+
+    if (jsonStr) {
+      Object.assign(driverConfigs, JSON.parse(jsonStr))
+    }
 }
 
 Object.entries(envConfigPaths)

--- a/hub/test/src/testDrivers/mockTestDrivers.ts
+++ b/hub/test/src/testDrivers/mockTestDrivers.ts
@@ -259,6 +259,8 @@ export function makeMockedDiskDriver() {
     }
   }
   class DiskDriverWrapper extends DiskDriver {
+    supportsETagMatching = false;
+
     async performWrite(args: PerformWriteArgs) : Promise<WriteResult> {
       const result = await super.performWrite(args)
       const filePath = path.resolve(tmpStorageDir, args.storageTopLevel, args.path)

--- a/hub/test/src/testServer.ts
+++ b/hub/test/src/testServer.ts
@@ -180,7 +180,7 @@ export function testServer() {
                             'content-length': 400,
                             authorization }, s)
         .then(path => {
-          t.equal(path, `http://potato.com/${testAddrs[0]}/foo.txt`)
+          t.equal(path.publicURL, `http://potato.com/${testAddrs[0]}/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'text/text')
@@ -189,7 +189,7 @@ export function testServer() {
                           { 'content-length': 400,
                             authorization }, s2))
         .then(path => {
-          t.equal(path, `http://potato.com/${testAddrs[0]}/foo.txt`)
+          t.equal(path.publicURL, `http://potato.com/${testAddrs[0]}/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'application/octet-stream')
@@ -218,7 +218,7 @@ export function testServer() {
                             'content-length': 400,
                             authorization }, s)
         .then(path => {
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}/foo.txt`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'text/text')
@@ -227,7 +227,7 @@ export function testServer() {
                           { 'content-length': 400,
                             authorization }, s2))
         .then(path => {
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}/foo.txt`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'application/octet-stream')
@@ -763,7 +763,7 @@ export function testServer() {
                             authorization }, s)
         .then(path => {
           // NOTE: the double-/ is *expected*
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}//foo/bar`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}//foo/bar`)
           t.equal(mockDriver.lastWrite.path, '/foo/bar')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'text/text')
@@ -772,7 +772,7 @@ export function testServer() {
                           { 'content-length': 400,
                             authorization }, s2))
         .then(path => {
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}/baz/foo.txt`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}/baz/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'baz/foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'application/octet-stream')
@@ -919,7 +919,7 @@ export function testServer() {
                             authorization }, s)
         .then(path => {
           // NOTE: the double-/ is *expected*
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}//foo/bar`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}//foo/bar`)
           t.equal(mockDriver.lastWrite.path, '/foo/bar')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'text/text')
@@ -928,7 +928,7 @@ export function testServer() {
                           { 'content-length': 400,
                             authorization }, s2))
         .then(path => {
-          t.equal(path, `${mockDriver.readUrl}${testAddrs[0]}/baz/foo.txt`)
+          t.equal(path.publicURL, `${mockDriver.readUrl}${testAddrs[0]}/baz/foo.txt`)
           t.equal(mockDriver.lastWrite.path, 'baz/foo.txt')
           t.equal(mockDriver.lastWrite.storageTopLevel, testAddrs[0])
           t.equal(mockDriver.lastWrite.contentType, 'application/octet-stream')

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -1,9 +1,12 @@
 import * as express from 'express'
 import * as expressWinston from 'express-winston'
 import * as cors from 'cors'
-import * as Path from 'path'
+import { promisify } from 'util'
+import { pipeline } from 'stream'
 import { Config, logger } from './config'
 import { GaiaDiskReader } from './server'
+
+const pipelineAsync = promisify(pipeline)
 
 export function makeHttpServer(config: Config) {
   const app = express()
@@ -15,43 +18,46 @@ export function makeHttpServer(config: Config) {
 
   app.use(cors())
 
-  app.get(/\/([a-zA-Z0-9-_]+)\/(.+)/, (req, res) => {
-    let filename = req.params[1]
-    if (filename.endsWith('/')) {
-      filename = filename.substring(0, filename.length - 1)
-    }
-    const address = req.params[0]
+  const fileHandler = async (req: express.Request, res: express.Response) => {
+    try {
+      let filename = req.params[1]
+      if (filename.endsWith('/')) {
+        filename = filename.substring(0, filename.length - 1)
+      }
+      const address = req.params[0]
 
-    if (config.cacheControl) {
-      res.set('Cache-Control', config.cacheControl)
-    }
+      if (config.cacheControl) {
+        res.set('Cache-Control', config.cacheControl)
+      }
 
-    return server.handleGet(address, filename)
-      .then((fileInfo) => {
-        const exists = fileInfo.exists
-        const contentType = fileInfo.contentType
-        const etag = fileInfo.etag
+      const isGetRequest = req.method === 'GET'
 
-        if (!exists) {
-          return res.status(404).send('File not found')
-        }
+      const fileInfo = await server.handleGet(address, filename, isGetRequest)
 
-        const opts = {
-          root: config.diskSettings.storageRootDirectory,
-          headers: {
-            'content-type': contentType,
-            'etag': etag
-          }
-        }
-        const path = Path.join(address, filename)
+      if (!fileInfo.exists) {
+        return res.status(404).send('File not found')
+      }
 
-        return res.sendFile(path, opts)
+      res.set({
+        'content-type': fileInfo.contentType,
+        'etag': fileInfo.etag,
+        'last-modified': fileInfo.lastModified.toUTCString(),
+        'content-length': fileInfo.contentLength
       })
-      .catch((err) => {
-        logger.error(err)
-        return res.status(400).send('Could not return file')
-      })
-  })
+
+      if (isGetRequest) {
+        await pipelineAsync(fileInfo.fileReadStream, res)
+      }
+      res.end()
+    } catch(err) {
+      logger.error(err)
+      return res.status(400).send('Could not return file')
+    }
+  }
+
+  const bucketFilePath = /\/([a-zA-Z0-9-_]+)\/(.+)/
+  app.get(bucketFilePath, fileHandler)
+  app.head(bucketFilePath, fileHandler)
 
   return app
 }

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -30,6 +30,7 @@ export function makeHttpServer(config: Config) {
       .then((fileInfo) => {
         const exists = fileInfo.exists
         const contentType = fileInfo.contentType
+        const etag = fileInfo.etag
 
         if (!exists) {
           return res.status(404).send('File not found')
@@ -38,7 +39,8 @@ export function makeHttpServer(config: Config) {
         const opts = {
           root: config.diskSettings.storageRootDirectory,
           headers: {
-            'content-type': contentType
+            'content-type': contentType,
+            'etag': etag
           }
         }
         const path = Path.join(address, filename)

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -16,7 +16,15 @@ export function makeHttpServer(config: Config) {
     winstonInstance: logger
   }))
 
-  app.use(cors())
+  app.use(cors({
+    origin: '*', 
+    // Set the Access-Control-Max-Age header to 24 hours.
+    maxAge: 86400, 
+    methods: 'GET,HEAD,OPTIONS',
+    // Expose ETag http response header to client
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    exposedHeaders: 'Content-Type,ETag'
+  }))
 
   const fileHandler = async (req: express.Request, res: express.Response) => {
     try {

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -21,7 +21,7 @@ export class GaiaDiskReader {
     return !path.includes('..')
   }
 
-  handleGet(topLevelDir: string, filename: string): Promise<{ exists: boolean, contentType?: string }> {
+  handleGet(topLevelDir: string, filename: string): Promise<{ exists: boolean, contentType?: string, etag?: string }> {
     const storageRoot = this.config.diskSettings.storageRootDirectory
     if (!storageRoot) {
       throw new Error('Misconfiguration: no storage root set')
@@ -43,7 +43,7 @@ export class GaiaDiskReader {
     try {
       const metadataJSON = fs.readFileSync(metadataPath).toString()
       const metadata = JSON.parse(metadataJSON)
-      const ret = { exists: true, contentType: metadata['content-type'] }
+      const ret = { exists: true, contentType: metadata['content-type'], etag: metadata['etag'] }
       return Promise.resolve().then(() => ret)
     } catch (e) {
       const ret = { exists: true, contentType: 'application/octet-stream' }

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -1,8 +1,22 @@
-import * as Path from 'path'
+import * as path from 'path'
 import * as fs from 'fs-extra'
+import { promisify } from 'util'
+import { pipeline } from 'stream'
+import { createHash } from 'crypto'
 import { DiskReaderConfig } from './config'
 
+const pipelineAsync = promisify(pipeline)
+
 const METADATA_DIRNAME = '.gaia-metadata'
+
+export type GetFileInfo = { 
+  exists: boolean; 
+  contentType?: string;
+  contentLength?: number;
+  etag?: string; 
+  lastModified?: Date;
+  fileReadStream?: fs.ReadStream;
+}
 
 export class GaiaDiskReader {
 
@@ -21,7 +35,7 @@ export class GaiaDiskReader {
     return !path.includes('..')
   }
 
-  handleGet(topLevelDir: string, filename: string): Promise<{ exists: boolean, contentType?: string, etag?: string }> {
+  async handleGet(topLevelDir: string, filename: string, openFileStream: boolean): Promise<GetFileInfo> {
     const storageRoot = this.config.diskSettings.storageRootDirectory
     if (!storageRoot) {
       throw new Error('Misconfiguration: no storage root set')
@@ -31,23 +45,39 @@ export class GaiaDiskReader {
       throw new Error('Invalid file name')
     }
 
-    const filePath = Path.join(storageRoot, topLevelDir, filename)
+    const filePath = path.join(storageRoot, topLevelDir, filename)
+    let stat: fs.Stats
     try {
-      fs.statSync(filePath)
+      stat = await fs.stat(filePath)
     } catch (e) {
-      const ret = { exists: false, contentType: undefined as string }
-      return Promise.resolve().then(() => ret)
+      return { exists: false }
     }
 
-    const metadataPath = Path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
+    let readStream: fs.ReadStream
     try {
-      const metadataJSON = fs.readFileSync(metadataPath).toString()
-      const metadata = JSON.parse(metadataJSON)
-      const ret = { exists: true, contentType: metadata['content-type'], etag: metadata['etag'] }
-      return Promise.resolve().then(() => ret)
-    } catch (e) {
-      const ret = { exists: true, contentType: 'application/octet-stream' }
-      return Promise.resolve().then(() => ret)
+      const metadataPath = path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
+      let metadata: {'content-type'?: string, 'etag'?: string} = { }
+      try {
+        metadata = await fs.readJson(metadataPath)
+      } catch (error) {
+        metadata['content-type'] = 'application/octet-stream'
+      }
+      if (openFileStream) {
+        readStream = fs.createReadStream(filePath)
+      }
+      return { 
+        exists: true, 
+        lastModified: stat.mtime, 
+        contentLength: stat.size, 
+        contentType: metadata['content-type'], 
+        etag: metadata['etag'],
+        fileReadStream: readStream
+      }
+    } catch (error) {
+      if (readStream) {
+        readStream.close()
+      }
+      throw error
     }
   }
 }

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -1,11 +1,6 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import { promisify } from 'util'
-import { pipeline } from 'stream'
-import { createHash } from 'crypto'
 import { DiskReaderConfig } from './config'
-
-const pipelineAsync = promisify(pipeline)
 
 const METADATA_DIRNAME = '.gaia-metadata'
 

--- a/reader/test/test.ts
+++ b/reader/test/test.ts
@@ -30,14 +30,14 @@ function testServer() {
     }
 
     const server = new GaiaDiskReader(config)
-    server.handleGet('12345', 'foo/bar.txt')
+    server.handleGet('12345', 'foo/bar.txt', true)
       .then((result) => {
         t.ok(result.exists, 'file exists')
         t.equal(result.contentType, 'application/potatoes', 'file has correct content type')
 
         // try with missing content-type
         fs.unlinkSync(Path.join(storageDir, '.gaia-metadata/12345/foo/bar.txt'))
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(result.exists, 'file exists')
@@ -47,7 +47,7 @@ function testServer() {
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata/12345/foo'))
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata/12345'))
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata'))
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(result.exists, 'file exists')
@@ -58,7 +58,7 @@ function testServer() {
         fs.rmdirSync(Path.join(storageDir, '12345/foo'))
         fs.rmdirSync(Path.join(storageDir, '12345'))
 
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(!result.exists, 'file does not exist')


### PR DESCRIPTION
## Description

This is the Gaia portion of the optimistic concurrency control changes I've been working on, referenced in this issue: blockstack/gaia#267

## Implementation

With this change, Gaia makes use of an optional etag (entity tag), included in the `if-match` request header, to validate that a file hasn't been changed externally since the client attempting to `write` to it last `read` it. Additionally, Gaia will now return a fresh `etag` in the response object returned on `write` operations.

This change helps prevent accidental overwrites and data loss, encouraging developers to create UIs to let users deal with these conflicts.

## Manual Testing

I've been testing this manually with a [custom Gaia hub](http://gaia.reedrosenbluth.com) running this code on digital ocean. I've been using a [small demo app](https://github.com/reedrosenbluth/bin) with [this version](https://github.com/blockstack/blockstack.js/pull/743) of blockstack.js

## Automated Testing

- [x] Modified existing unit tests to check for existence/correctness of etag

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [ ] Submission contains tests that cover any and all new functionality or code changes.

- [ ] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
