### PR TITLE
Update unfair table

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,25 +585,15 @@ Currently, the service will only allow up to 20 write requests per second and a 
 file size of 5MB. However, these limitations are only for our service, if you deploy
 your own Gaia hub, these limitations are not necessary.
 
-# Project Comparison
+# Features
 
-Here's how Gaia stacks up against other decentralized storage systems.  Features
-that are common to all storage systems are omitted for brevity.
-
-| **Features**                | Gaia | [Sia](https://sia.tech/) | [Storj](https://storj.io/) | [IPFS](https://ipfs.io) | [DAT](https://datproject.org) | [SSB](https://www.scuttlebutt.nz/) |
-|-----------------------------|------|--------------------------|----------------------------|-------------------------|-------------------------------|------------------------------------|
-| User controls where data is hosted           | X |   |   |   |   |   |
-| Data stored redundantly                      | optional | X | X | optional | optional | optional |
-| Data is read/write                           | X |   |   |   | X | X |
-| Data can be deleted                          | X | X |   |   | X | X |
-| Data can be listed                           | X | X | X |   | X | X |
-| Deleted data space is reclaimed              | X | X | X | X |   |   | 
-| Data lookups have predictable performance    | X | X | X |   |   |   |
-| Writes permission can be delegated           | X |   |   |   |   |   |
-| Listing permission can be delegated          | X |   |   |   |   |   |
-| Data is globally addressable                 | X | X | X | X | X |   | 
-| Needs a cryptocurrency to work               |   | X | X |   |   |   |
-| Needs FIAT currency to work                  | X |   |   |   |   |   |
-| Data is content-addressed                    |   | X | X | X | X | X |
-| Data stored geographically distributed       | optional | X | X | X | X | X |
-| Pricing (per TB per month)                   | Various | ~$2 | $10 | free, files can be lost | free, files can be lost |  |
+- User controls where data is hosted
+- Data can be viewed in a normal Web browser
+- Data can be stored redundantly (depends on the storage you choose)
+- Data can be listed and deleted
+- Deleted data space is reclaimed
+- Data lookups have as predictable performance as your storage
+- Writes and listing permission can be delegated
+- Data is globally addressable
+- Useable with free/trial storage packages
+- Noo needs cryptocurrency to work, just storage

--- a/README.md
+++ b/README.md
@@ -593,15 +593,17 @@ that are common to all storage systems are omitted for brevity.
 | **Features**                | Gaia | [Sia](https://sia.tech/) | [Storj](https://storj.io/) | [IPFS](https://ipfs.io) | [DAT](https://datproject.org) | [SSB](https://www.scuttlebutt.nz/) |
 |-----------------------------|------|--------------------------|----------------------------|-------------------------|-------------------------------|------------------------------------|
 | User controls where data is hosted           | X |   |   |   |   |   |
-| Data can be viewed in a normal Web browser   | X |   |   | X |   |   |
+| Data stored redundantly                      | optional | X | X | optional | optional | optional |
 | Data is read/write                           | X |   |   |   | X | X |
-| Data can be deleted                          | X |   |   |   | X | X |
+| Data can be deleted                          | X | X |   |   | X | X |
 | Data can be listed                           | X | X | X |   | X | X |
 | Deleted data space is reclaimed              | X | X | X | X |   |   | 
-| Data lookups have predictable performance    | X |   | X |   |   |   |
+| Data lookups have predictable performance    | X | X | X |   |   |   |
 | Writes permission can be delegated           | X |   |   |   |   |   |
 | Listing permission can be delegated          | X |   |   |   |   |   |
-| Supports multiple backends natively          | X |   | X |   |   |   |
 | Data is globally addressable                 | X | X | X | X | X |   | 
 | Needs a cryptocurrency to work               |   | X | X |   |   |   |
+| Needs FIAT currency to work                  | X |   |   |   |   |   |
 | Data is content-addressed                    |   | X | X | X | X | X |
+| Data stored geographically distributed       | optional | X | X | X | X | X |
+| Pricing (per TB per month)                   | Various | ~$2 | $10 | free, files can be lost | free, files can be lost |  |


### PR DESCRIPTION
## Goal of PR

Correcting information in the comparing table. (I'll be happy to remove the whole table because it compares apples to pears. Pointless, more below.)

## Changes

> Data can be viewed in a normal Web browser

Sorry guys, but that's a stupid question. Every decentralized storage solution can be viewable in a browser with a CDN (or middle server). Everything that is really decentralized needs a full node. Because of that, it's not viewable in a browser, without a full node. Gaia will be decentralized when I can add multiple storages to it, but that's optional.

> Data can be deleted

On Sia, files can be deleted, I think this is just a simple mistake.

> Data lookups have predictable performance

I'm watching 1080p films from a mounted Sia drive. That's improved a lot and will be improved more.

> Supports multiple backends natively

Ahh, here we go again. What does this question mean? On Sia, every file stored on 30 geographically distributed hosts. I think it is multiple. You can increase/decrease the redundancy also.
I removed this line, because every competitor is a backend, while Gaia is the client. You can use Sia with Gaia (with a mounted s3 drive), that's a stupid comparison. Apple is not comparable with pear.

> Data is read/write

What does this question mean?

I also added some new rows.

Note that I have strong experience with Sia, but I don't know much about Dat and SSB (that's a social media, not storage, why is it on the list? Apple and pear again.) IPFS is a protocol, FileCoin is the storage (yeah, not working yet, but again, that's not comparable).