### PR TITLE
Reader http HEAD support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,7 @@
             "runtimeArgs": ["--nolazy", "-r", "ts-node/register/transpile-only"],
             "env": {
                 "DRIVER_CONFIG_TEST_DATA": "${workspaceFolder}/hub/configs/drivers.json",
+                "TS_NODE_PROJECT": "${workspaceFolder}/hub/test/tsconfig.json"
             },
             "cwd": "${workspaceFolder}/hub",
             "outputCapture": "std"

--- a/hub/package.json
+++ b/hub/package.json
@@ -69,7 +69,7 @@
     "lint": "eslint --ext .ts ./src -f unix",
     "lint:fix": "eslint --ext .ts ./src --fix",
     "test:build": "tsc -p ./test/tsconfig.json",
-    "test:coverage": "cross-env NODE_ENV=test nyc node ./test/src/index.ts",
+    "test:coverage": "cross-env NODE_ENV=test LOCAL_DRIVER_CONFIG_TEST_DATA=configs/drivers.json nyc node ./test/src/index.ts",
     "test": "npm-run-all build --parallel lint test:coverage"
   },
   "repository": {

--- a/hub/test/src/testDrivers/InMemoryDriver.ts
+++ b/hub/test/src/testDrivers/InMemoryDriver.ts
@@ -35,7 +35,9 @@ export class InMemoryDriver implements DriverModel {
         res.set({
           'Content-Type': matchingFile.contentType,
           'ETag': matchingFile.etag,
-          'Cache-Control': (config || {}).cacheControl
+          'Cache-Control': (config || {}).cacheControl,
+          'Content-Length': matchingFile.content.byteLength,
+          'Last-Modified': matchingFile.lastModified.toUTCString()
         }).send(matchingFile.content)
       } else {
         res.status(404).send('Could not return file')

--- a/hub/test/src/testDrivers/integrationTestDrivers.ts
+++ b/hub/test/src/testDrivers/integrationTestDrivers.ts
@@ -19,7 +19,7 @@ import * as gaiaReader from '../../../../reader/src/http'
  *  - json string
  *  - base64 encoded json string
  */
-const driverConfigTestData = process.env.DRIVER_CONFIG_TEST_DATA
+const driverConfigTestData = process.env.DRIVER_CONFIG_TEST_DATA || process.env.LOCAL_DRIVER_CONFIG_TEST_DATA
 
 const envConfigPaths = { 
   az: process.env.AZ_CONFIG_PATH, 
@@ -39,7 +39,12 @@ if (driverConfigTestData) {
     let jsonStr;
     if (driverConfigTestData.endsWith('.json')) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as json file for driver config')
-        jsonStr = fs.readFileSync(driverConfigTestData, {encoding: 'utf8'})
+        if (!fs.existsSync(driverConfigTestData)) {
+          console.error(`File not found: ${path.resolve(driverConfigTestData)}`)
+          console.error(`Cannot load storage driver credentials file, integration tests will not run`)
+        } else {
+          jsonStr = fs.readFileSync(driverConfigTestData, {encoding: 'utf8'})
+        }
     } else if (/^\s*{/.test(driverConfigTestData)) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as json blob for driver config')
         jsonStr = driverConfigTestData
@@ -47,7 +52,10 @@ if (driverConfigTestData) {
         console.log('Using DRIVER_CONFIG_TEST_DATA env var as b64 encoded json blob for driver config')
         jsonStr = new Buffer(driverConfigTestData, 'base64').toString('utf8')
     }
-    Object.assign(driverConfigs, JSON.parse(jsonStr))
+
+    if (jsonStr) {
+      Object.assign(driverConfigs, JSON.parse(jsonStr))
+    }
 }
 
 Object.entries(envConfigPaths)

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -1,9 +1,12 @@
 import * as express from 'express'
 import * as expressWinston from 'express-winston'
 import * as cors from 'cors'
-import * as Path from 'path'
+import { promisify } from 'util'
+import { pipeline } from 'stream'
 import { Config, logger } from './config'
 import { GaiaDiskReader } from './server'
+
+const pipelineAsync = promisify(pipeline)
 
 export function makeHttpServer(config: Config) {
   const app = express()
@@ -15,43 +18,46 @@ export function makeHttpServer(config: Config) {
 
   app.use(cors())
 
-  app.get(/\/([a-zA-Z0-9-_]+)\/(.+)/, (req, res) => {
-    let filename = req.params[1]
-    if (filename.endsWith('/')) {
-      filename = filename.substring(0, filename.length - 1)
-    }
-    const address = req.params[0]
+  const fileHandler = async (req: express.Request, res: express.Response) => {
+    try {
+      let filename = req.params[1]
+      if (filename.endsWith('/')) {
+        filename = filename.substring(0, filename.length - 1)
+      }
+      const address = req.params[0]
 
-    if (config.cacheControl) {
-      res.set('Cache-Control', config.cacheControl)
-    }
+      if (config.cacheControl) {
+        res.set('Cache-Control', config.cacheControl)
+      }
 
-    return server.handleGet(address, filename)
-      .then((fileInfo) => {
-        const exists = fileInfo.exists
-        const contentType = fileInfo.contentType
-        const etag = fileInfo.etag
+      const isFileRead = req.method === 'GET'
 
-        if (!exists) {
-          return res.status(404).send('File not found')
-        }
+      const fileInfo = await server.handleGet(address, filename, isFileRead)
 
-        const opts = {
-          root: config.diskSettings.storageRootDirectory,
-          headers: {
-            'content-type': contentType,
-            'etag': etag
-          }
-        }
-        const path = Path.join(address, filename)
+      if (!fileInfo.exists) {
+        return res.status(404).send('File not found')
+      }
 
-        return res.sendFile(path, opts)
+      res.set({
+        'content-type': fileInfo.contentType,
+        'etag': fileInfo.etag,
+        'last-modified': fileInfo.lastModified.toUTCString(),
+        'content-length': fileInfo.contentLength
       })
-      .catch((err) => {
-        logger.error(err)
-        return res.status(400).send('Could not return file')
-      })
-  })
+
+      if (isFileRead) {
+        await pipelineAsync(fileInfo.fileReadStream, res)
+      }
+      res.end()
+    } catch(err) {
+      logger.error(err)
+      return res.status(400).send('Could not return file')
+    }
+  }
+
+  const bucketFilePath = /\/([a-zA-Z0-9-_]+)\/(.+)/
+  app.get(bucketFilePath, fileHandler)
+  app.head(bucketFilePath, fileHandler)
 
   return app
 }

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -30,9 +30,9 @@ export function makeHttpServer(config: Config) {
         res.set('Cache-Control', config.cacheControl)
       }
 
-      const isFileRead = req.method === 'GET'
+      const isGetRequest = req.method === 'GET'
 
-      const fileInfo = await server.handleGet(address, filename, isFileRead)
+      const fileInfo = await server.handleGet(address, filename, isGetRequest)
 
       if (!fileInfo.exists) {
         return res.status(404).send('File not found')
@@ -45,7 +45,7 @@ export function makeHttpServer(config: Config) {
         'content-length': fileInfo.contentLength
       })
 
-      if (isFileRead) {
+      if (isGetRequest) {
         await pipelineAsync(fileInfo.fileReadStream, res)
       }
       res.end()

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -51,7 +51,12 @@ export class GaiaDiskReader {
     let readStream: fs.ReadStream
     try {
       const metadataPath = path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
-      const metadata = await fs.readJson(metadataPath)
+      let metadata: {'content-type'?: string, 'etag'?: string} = { }
+      try {
+        metadata = await fs.readJson(metadataPath)
+      } catch (error) {
+        metadata['content-type'] = 'application/octet-stream'
+      }
       if (openRead) {
         readStream = fs.createReadStream(filePath)
       }
@@ -67,6 +72,7 @@ export class GaiaDiskReader {
       if (readStream) {
         readStream.close()
       }
+      throw error
     }
   }
 }

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -1,8 +1,17 @@
-import * as Path from 'path'
+import * as path from 'path'
 import * as fs from 'fs-extra'
 import { DiskReaderConfig } from './config'
 
 const METADATA_DIRNAME = '.gaia-metadata'
+
+export type GetFileInfo = { 
+  exists: boolean; 
+  contentType?: string;
+  contentLength?: number;
+  etag?: string; 
+  lastModified?: Date;
+  fileReadStream?: fs.ReadStream;
+}
 
 export class GaiaDiskReader {
 
@@ -21,7 +30,7 @@ export class GaiaDiskReader {
     return !path.includes('..')
   }
 
-  handleGet(topLevelDir: string, filename: string): Promise<{ exists: boolean, contentType?: string, etag?: string }> {
+  async handleGet(topLevelDir: string, filename: string, openRead: boolean): Promise<GetFileInfo> {
     const storageRoot = this.config.diskSettings.storageRootDirectory
     if (!storageRoot) {
       throw new Error('Misconfiguration: no storage root set')
@@ -31,23 +40,33 @@ export class GaiaDiskReader {
       throw new Error('Invalid file name')
     }
 
-    const filePath = Path.join(storageRoot, topLevelDir, filename)
+    const filePath = path.join(storageRoot, topLevelDir, filename)
+    let stat: fs.Stats
     try {
-      fs.statSync(filePath)
+      stat = await fs.stat(filePath)
     } catch (e) {
-      const ret = { exists: false, contentType: undefined as string }
-      return Promise.resolve().then(() => ret)
+      return { exists: false }
     }
 
-    const metadataPath = Path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
+    let readStream: fs.ReadStream
     try {
-      const metadataJSON = fs.readFileSync(metadataPath).toString()
-      const metadata = JSON.parse(metadataJSON)
-      const ret = { exists: true, contentType: metadata['content-type'], etag: metadata['etag'] }
-      return Promise.resolve().then(() => ret)
-    } catch (e) {
-      const ret = { exists: true, contentType: 'application/octet-stream' }
-      return Promise.resolve().then(() => ret)
+      const metadataPath = path.join(storageRoot, METADATA_DIRNAME, topLevelDir, filename)
+      const metadata = await fs.readJson(metadataPath)
+      if (openRead) {
+        readStream = fs.createReadStream(filePath)
+      }
+      return { 
+        exists: true, 
+        lastModified: stat.mtime, 
+        contentLength: stat.size, 
+        contentType: metadata['content-type'], 
+        etag: metadata['etag'],
+        fileReadStream: readStream
+      }
+    } catch (error) {
+      if (readStream) {
+        readStream.close()
+      }
     }
   }
 }

--- a/reader/test/test.ts
+++ b/reader/test/test.ts
@@ -30,14 +30,14 @@ function testServer() {
     }
 
     const server = new GaiaDiskReader(config)
-    server.handleGet('12345', 'foo/bar.txt')
+    server.handleGet('12345', 'foo/bar.txt', true)
       .then((result) => {
         t.ok(result.exists, 'file exists')
         t.equal(result.contentType, 'application/potatoes', 'file has correct content type')
 
         // try with missing content-type
         fs.unlinkSync(Path.join(storageDir, '.gaia-metadata/12345/foo/bar.txt'))
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(result.exists, 'file exists')
@@ -47,7 +47,7 @@ function testServer() {
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata/12345/foo'))
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata/12345'))
         fs.rmdirSync(Path.join(storageDir, '.gaia-metadata'))
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(result.exists, 'file exists')
@@ -58,7 +58,7 @@ function testServer() {
         fs.rmdirSync(Path.join(storageDir, '12345/foo'))
         fs.rmdirSync(Path.join(storageDir, '12345'))
 
-        return server.handleGet('12345', 'foo/bar.txt')
+        return server.handleGet('12345', 'foo/bar.txt', true)
       })
       .then((result) => {
         t.ok(!result.exists, 'file does not exist')


### PR DESCRIPTION
## Goal of PR

* Implement http HEAD request support in `reader` -- required for future efficient etag lookups in blockstack.js.
* Fix DDoS vulnerability in `reader` by refactoring blocking/syncronous file system operations.
* Implement unit tests for ensuring correct read-endpoint HTTP headers for all drivers.
* Use storage credentials file for integration testing if available when running npm test script.

## Automated Testing

Integration tests against all supported drivers. 

## Submission Checklist

- [ ] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`
  - (will PR into develop once the etag/MVCC PR is merged into develop)

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [ ] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.
  - (need to update the CHANGELOG) 
- [x] Author has agreed to our contributor's agreement.
