### PR TITLE
Feature/fix express cors

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -44,15 +44,15 @@ These driver may require you to provide additional credentials for performing wr
 
 In order for a Gaia hub to operate properly CORS must be configured.
 
-For the **write endpoint**, you must configure your server to include the following headers:
+For the **write endpoint**, you must configure your server to respond to [CORS requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). The minimum required HTTP response headers must include:
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE`
-- `Access-Control-Allow-Headers: Authorization, If-Match`
+- `Access-Control-Allow-Headers: Authorization, Content-Type, If-Match`
 
 
 For the **read endpoint**, you must configure your storage driver to include the following headers:
-- `Access-Control-Allow-Methods: GET`
 - `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, HEAD`
 - `Access-Control-Expose-Headers: ETag`
 
 Here's an example of a storage driver (S3) configuration:

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -50,9 +50,7 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
     methods: 'DELETE,POST,GET,OPTIONS,HEAD',
     // Allow the client to include If-Match header in http requests
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
-    allowedHeaders: ['Authorization', 'If-Match'],
-    // Specify the `Access-Control-Allow-Credentials` header
-    credentials: true
+    allowedHeaders: 'Authorization,Content-Type,If-Match'
   })
   
   app.use(corsConfig)

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -43,8 +43,22 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
   app.use(expressWinston.logger({
     winstonInstance: logger }))
 
-  // Set the Access-Control-Max-Age header to 24 hours.
-  app.use(cors({maxAge: 86400}))
+  const corsConfig = cors({
+    origin: '*',
+    // Set the Access-Control-Max-Age header to 24 hours.
+    maxAge: 86400, 
+    // Allow the client to include If-Match header in http requests
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+    allowedHeaders: ['Authorization', 'If-Match'],
+    // Specify the `Access-Control-Allow-Credentials` header
+    credentials: true
+  })
+  
+  app.use(corsConfig)
+
+  // Enabling CORS Pre-Flight
+  // https://www.npmjs.com/package/cors#enabling-cors-pre-flight
+  app.options('*', corsConfig)
 
   // sadly, express doesn't like to capture slashes.
   //  but that's okay! regexes solve that problem

--- a/hub/src/server/http.ts
+++ b/hub/src/server/http.ts
@@ -47,6 +47,7 @@ export function makeHttpServer(config: HubConfigInterface): { app: express.Appli
     origin: '*',
     // Set the Access-Control-Max-Age header to 24 hours.
     maxAge: 86400, 
+    methods: 'DELETE,POST,GET,OPTIONS,HEAD',
     // Allow the client to include If-Match header in http requests
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
     allowedHeaders: ['Authorization', 'If-Match'],

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -23,7 +23,7 @@ export function makeHttpServer(config: Config) {
     methods: 'GET,HEAD,OPTIONS',
     // Expose ETag http response header to client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
-    exposedHeaders: ['ETag']
+    exposedHeaders: 'Content-Type,ETag'
   }))
 
   const fileHandler = async (req: express.Request, res: express.Response) => {

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -16,7 +16,14 @@ export function makeHttpServer(config: Config) {
     winstonInstance: logger
   }))
 
-  app.use(cors())
+  app.use(cors({
+    origin: '*', 
+    // Set the Access-Control-Max-Age header to 24 hours.
+    maxAge: 86400, 
+    // Expose ETag http response header to client
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    exposedHeaders: ['ETag']
+  }))
 
   const fileHandler = async (req: express.Request, res: express.Response) => {
     try {

--- a/reader/src/http.ts
+++ b/reader/src/http.ts
@@ -20,6 +20,7 @@ export function makeHttpServer(config: Config) {
     origin: '*', 
     // Set the Access-Control-Max-Age header to 24 hours.
     maxAge: 86400, 
+    methods: 'GET,HEAD,OPTIONS',
     // Expose ETag http response header to client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
     exposedHeaders: ['ETag']

--- a/reader/src/server.ts
+++ b/reader/src/server.ts
@@ -1,11 +1,6 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import { promisify } from 'util'
-import { pipeline } from 'stream'
-import { createHash } from 'crypto'
 import { DiskReaderConfig } from './config'
-
-const pipelineAsync = promisify(pipeline)
 
 const METADATA_DIRNAME = '.gaia-metadata'
 


### PR DESCRIPTION
Fix Express server CORS config on `hub` and `reader` so that they work as expected when hosted without a http proxy (e.g. running on port 80/443 without nginx). 