### PR TITLE
fix: throw PreconditionFailedError if if-none-match is set and file exists

### DIFF
--- a/hub/CHANGELOG.md
+++ b/hub/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1]
+### Fixed
+- Return 412 Precondition Failed Error if `If-None-Match` header is set to `*` on a
+  write request, but the file already exists.
+
 ## [2.8.0]
 ### Added
 - Return ETag in response body of all requests.

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gaia-hub",
-  "version": "2.7.0",
+  "version": "2.8.1",
   "description": "",
   "main": "index.js",
   "license": "MIT",

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -220,6 +220,9 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
       if (error.body && error.body.Code === 'ConditionNotMet') {
         throw new PreconditionFailedError('The entity you are trying to create already exists')
       }
+      if (error.body && error.body.Code === 'BlobAlreadyExists') {
+        throw new PreconditionFailedError('Misuse of the if-none-match header. Expected to be * on write requests.')
+      }
       if (error.body && error.body.Code === 'InvalidBlockList') {
         throw new ConflictError('Likely failed due to concurrent PUTs to the same file')
       }

--- a/hub/src/server/drivers/AzDriver.ts
+++ b/hub/src/server/drivers/AzDriver.ts
@@ -218,10 +218,10 @@ class AzDriver implements DriverModel, DriverModelTestMethods {
     } catch (error) {
       logger.error(`failed to store ${azBlob} in ${this.bucket}: ${error}`)
       if (error.body && error.body.Code === 'ConditionNotMet') {
-        throw new PreconditionFailedError('The entity you are trying to create already exists')
+        throw new PreconditionFailedError('The provided ETag does not match that of the resource on the server')
       }
       if (error.body && error.body.Code === 'BlobAlreadyExists') {
-        throw new PreconditionFailedError('Misuse of the if-none-match header. Expected to be * on write requests.')
+        throw new PreconditionFailedError('The entity you are trying to create already exists')
       }
       if (error.body && error.body.Code === 'InvalidBlockList') {
         throw new ConflictError('Likely failed due to concurrent PUTs to the same file')

--- a/hub/test/src/testDrivers.ts
+++ b/hub/test/src/testDrivers.ts
@@ -113,7 +113,11 @@ function testDriver(testName: string, mockTest: boolean, dataMap: {key: string, 
             ifNoneMatch: '*'
           })
         } catch(err) {
-          t.ok(err, 'Should fail to write new file if file already exists')
+          if (err.name === 'PreconditionFailedError') {
+            t.ok(err, 'Should fail to write new file if file already exists')
+          } else {
+            t.error('Should throw PreconditionFailedError');
+          }
         }
 
         try {

--- a/hub/test/src/testHttp.ts
+++ b/hub/test/src/testHttp.ts
@@ -232,6 +232,13 @@ export function testHttpWithInMemoryDriver() {
         .send(blob)
         .expect(412)
 
+      await request(app).post(path)
+        .set('Content-Type', 'application/octet-stream')
+        .set('Authorization', authorization)
+        .set('If-None-Match', '*')
+        .send(blob)
+        .expect(412)
+
       try {
         const largePayload = new PassThrough()
         largePayload.end('x'.repeat(1000))


### PR DESCRIPTION
## Goal of PR

This PR fixes a bug in which a 500 error was getting thrown instead of a 412 when write request was made with the if-none-match header set, and the file attempting to be written already exists.

#306

## Automated Testing

Added an integration test.

## Submission Checklist

- [x] Based on correct branch: feature submissions should be on `develop`, hotfixes should be on `master`

- [x] The code passes our eslint definitions, unit tests, and
      contains correct TypeFlow annotations.

- [x] Submission contains tests that cover any and all new functionality or code changes.

- [x] Submission documents any new features or endpoints, and describes how developers
      would be expected to interact with them.

- [x] Author has agreed to our contributor's agreement.
