### PR TITLE
fixed some broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and interactions between developer APIs and the Gaia service.
 
 Developers who wish to _use_ the Gaia storage system should see the
 `blockstack.js` APIs
-documented [here](https://github.com/blockstack/blockstack.js/tree/master/src/storage) and [here](http://blockstack.github.io/blockstack.js/#storage).
+documented [here](https://docs.stacks.co/build-apps/references/gaia) and [here](https://github.com/hirosystems/stacks.js/tree/master/packages/storage).
 
 If you would like to deploy your own hub, there are instructions available [here](https://docs.blockstack.org/storage/hub-operation.html)
 


### PR DESCRIPTION
Several links of the documentation are broken and return a 404 error. 
Fixed two of them here.
